### PR TITLE
Add credentials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ initialState == {
 | url | String | Actual url of the resource (required) |
 | pluralName | String | Plural name of the resource (optional) |
 | actions | Object | Action extra options, merged with defaults (optional) |
+| credentials | String | Credentials option according to Fetch polyfill doc for sending cookies (optional) |
 
 #### Default actions options
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -26,6 +26,9 @@ const buildFetchOpts = ({context, actionOpts}) => {
   if (actionOpts.headers) {
     opts.headers = {...opts.headers, ...actionOpts.headers};
   }
+  if (actionOpts.credentials) {
+    opts.credentials = actionOpts.credentials;
+  }
   const hasBody = /^(POST|PUT|PATCH)$/i.test(opts.method);
   if (context && hasBody) {
     opts.body = JSON.stringify(context);
@@ -36,10 +39,10 @@ const buildFetchOpts = ({context, actionOpts}) => {
 
 const isSuccess = status => status >= 200 && status < 300;
 
-const createActions = ({name, pluralName, url: defaultUrl, actions = {}}) => (
+const createActions = ({name, pluralName, url: defaultUrl, actions = {}, credentials}) => (
   Object.keys(actions).reduce((actionFuncs, actionKey) => {
     const action = actions[actionKey];
-    const actionOpts = actions[actionKey];
+    const actionOpts = {...actions[actionKey], credentials};
     const type = getActionType({name, action, actionKey});
     const url = action.url || defaultUrl;
     const urlParams = parseUrlParams(url);


### PR DESCRIPTION
Handle credentials option in createActions function in order to manage cookies for fetch requests.

In according to the official Fetch polyfill documentation, the credentials is a string set in fetch options object.