### PR TITLE
feat(get): add assignResponse option

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -60,13 +60,26 @@ const reducers = {
           isFetchingItem: true,
           didInvalidateItem: false
         };
-      case 'resolved':
+      case 'resolved': {
+        const actionOpts = action.options || {};
+        const item = action.body;
+        const update = {};
+        if (actionOpts.assignResponse) {
+          const updatedItems = state.items;
+          const listItemIndex = updatedItems.findIndex(el => el.id === item.id);
+          if (listItemIndex !== -1) {
+            updatedItems.splice(listItemIndex, 1, item);
+            update.items = updatedItems.slice();
+          }
+        }
         return {...state,
           isFetchingItem: false,
           didInvalidateItem: false,
-          item: action.body,
-          lastUpdatedItem: action.receivedAt
+          lastUpdatedItem: action.receivedAt,
+          item,
+          ...update
         };
+      }
       case 'rejected':
         return {...state,
           isFetchingItem: false,

--- a/test/spec/reducers.spec.js
+++ b/test/spec/reducers.spec.js
@@ -96,6 +96,32 @@ describe('createReducers', () => {
     expect(reducers(pendingState, {type, status, context, err: {}, receivedAt}))
       .toEqual({...pendingState, isFetchingItem: false});
   });
+  it('should handle GET with option `assignResponse`', () => {
+    const actionKey = 'get';
+    const actionOpts = {...defaultActions[actionKey], assignResponse: true};
+    const customReducers = createReducers({name, actions: actionOpts, types});
+    const type = types[getActionKey({name, actionKey, actionOpts})];
+    const initialItems = [{id: 1, firstName: 'Olivier', lastName: 'Louvignes'}];
+    const customInitialState = {...initialState, items: initialItems};
+    const context = {id: 1};
+    let status;
+
+    status = 'pending';
+    const pendingState = customReducers(customInitialState, {type, status, context});
+    expect(pendingState)
+      .toEqual({...customInitialState, isFetchingItem: true, didInvalidateItem: false});
+
+    status = 'resolved';
+    const body = {id: 1, firstName: 'Olivia', lastName: 'Louvignes'};
+    const receivedAt = Date.now();
+    const expectedItems = [body];
+    expect(customReducers(pendingState, {type, status, context, options: actionOpts, body, receivedAt}))
+      .toEqual({...pendingState, isFetchingItem: false, items: expectedItems, item: body, lastUpdatedItem: receivedAt});
+
+    status = 'rejected';
+    expect(customReducers(pendingState, {type, status, context, options: actionOpts, err: {}, receivedAt}))
+      .toEqual({...pendingState, isFetchingItem: false});
+  });
   it('should handle UPDATE action', () => {
     const actionKey = 'update';
     const actionOpts = defaultActions[actionKey];


### PR DESCRIPTION
Able to assign the response from a GET request into items field. So the item can be updated without performing another FETCH request.