### PR TITLE
Remove hard ‘isomorphic-fetch’ dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Generates types, actions and reducers for you to easily interact with any REST A
 
 Saves you from writing a lot of boilerplate code and ensures that your code stays [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
 
-- Relies on [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) to perform HTTP requests.
-
 - Requires [redux-thunk](https://github.com/gaearon/redux-thunk) to handle async actions.
+
+- Relies on [fetch](https://fetch.spec.whatwg.org/) to perform HTTP requests. If you want to use this in environments without a builtin `fetch` implementation, you need to [bring your own custom fetch polyfill](advanced/CustomFetch).
 
 ## Usage
 

--- a/docs/advanced/CustomFetch.md
+++ b/docs/advanced/CustomFetch.md
@@ -1,0 +1,9 @@
+# Custom Fetch
+
+You can easily plug in your own fetch library:
+
+```js
+import fetch from 'fetch-everywhere';
+import {defaultGlobals} from 'redux-rest-resource';
+Object.assign(defaultGlobals, {fetch});
+```

--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -6,3 +6,4 @@ Some more advanced examples
 * [Assign Update Response](AssignUpdateResponse.md)
 * [Resource Combination](ResourceCombination.md)
 * [Custom Promise](CustomPromise.md)
+* [Custom fetch](CustomFetch.md)

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "docs:publish": "rimraf _book; npm run docs:build && gh-pages -d _book",
     "prepublish": "npm run compile"
   },
-  "dependencies": {
-    "isomorphic-fetch": "^2.2.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
@@ -46,6 +44,7 @@
     "expect": "^1.20.2",
     "gh-pages": "^0.12.0",
     "gitbook-cli": "^2.3.0",
+    "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4",
     "mocha": "^3.3.0",
     "nock": "^9.0.13",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,7 +3,7 @@
 import {getActionType} from './../types';
 import {applyTransformPipeline, buildTransformPipeline} from './transform';
 import {parseUrlParams} from './../helpers/url';
-import {buildFetchUrl, buildFetchOpts, fetch} from './../helpers/fetch';
+import fetch, {buildFetchUrl, buildFetchOpts} from './../helpers/fetch';
 import {pick, ucfirst} from './../helpers/util';
 
 import {defaultTransformResponsePipeline} from './../defaults';

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -1,4 +1,4 @@
-
+/* global fetch */
 
 const defaultActions = {
   create: {method: 'POST', alias: 'save'},
@@ -44,7 +44,8 @@ const defaultState = {
 const initialState = Object.keys(defaultState).reduce((soFar, key) => ({...soFar, ...defaultState[key]}), {});
 
 const defaultGlobals = {
-  Promise
+  Promise,
+  fetch
 };
 
 export {

--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -1,4 +1,5 @@
-import baseFetch from 'isomorphic-fetch';
+/* global fetch */
+
 import {isObject, startsWith} from './util';
 import {encodeUriQuery, encodeUriSegment, replaceUrlParamFromUrl, replaceQueryStringParamFromUrl, splitUrlByProtocolAndDomain} from './url';
 import {defaultGlobals, defaultHeaders} from './../defaults';
@@ -63,13 +64,13 @@ export const buildFetchOpts = ({context, contextOpts, actionOpts}) => {
   return opts;
 };
 
-export const fetch = (url, options = {}) => {
+export default (url, options = {}) => {
   // Support options.query
   const builtUrl = Object.keys(options.query || []).reduce((wipUrl, queryParam) => {
     const queryParamValue = options.query[queryParam];
     return replaceQueryStringParamFromUrl(wipUrl, queryParam, queryParamValue);
   }, url);
-  return (options.Promise || defaultGlobals.Promise).resolve(baseFetch(builtUrl, options))
+  return (options.Promise || defaultGlobals.Promise).resolve((defaultGlobals.fetch || fetch)(builtUrl, options))
     .then((res) => {
       if (!res.ok) {
         const contentType = res.headers.get('Content-Type');
@@ -81,5 +82,3 @@ export const fetch = (url, options = {}) => {
       return res;
     });
 };
-
-export default fetch;

--- a/test/spec/actions.spec.js
+++ b/test/spec/actions.spec.js
@@ -3,14 +3,16 @@ import configureMockStore from 'redux-mock-store';
 import expect from 'expect';
 import nock from 'nock';
 import thunk from 'redux-thunk';
+import fetch from 'isomorphic-fetch';
 
-import {createResource, defaultActions, defaultHeaders} from '../../src';
+import {createResource, defaultActions, defaultHeaders, defaultGlobals} from '../../src';
 import {getActionType} from '../../src/types';
 import {createActions, getActionName} from '../../src/actions';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
+before(() => { Object.assign(defaultGlobals, {fetch}); });
 
 try { require('debug-utils'); } catch (err) {}; // eslint-disable-line
 


### PR DESCRIPTION
Make it as configurable / optional as the Promise soft dependency already is.

Probably solves part of #10 (React Native already comes with its own `fetch` implementation).

-----

This is a breaking change, if you’re in an environment without global fetch, you need to do this:

```
yarn add isomorphic-fetch
```

And then add this somewhere appropriate:

```
import fetch from 'fetch-everywhere';
import {defaultGlobals} from 'redux-rest-resource';
Object.assign(defaultGlobals, {fetch});
```