### PR TITLE
Bugfix: Evaluate function actionOpts on every request

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -31,12 +31,13 @@ const createActions = ({name, pluralName, url: defaultUrl, actions = {}, credent
       if (typeof actionUrl === 'function') { url = actionUrl(getState); }
       const urlParams = parseUrlParams(url);
       const fetchUrl = buildFetchUrl({url, urlParams, context, contextOpts});
+      const dynamicOpts = {};
       Object.keys(actionOpts).forEach((key) => {
         if (typeof actionOpts[key] === 'function') {
-          actionOpts[key] = actionOpts[key](getState);
+          dynamicOpts[key] = actionOpts[key](getState);
         }
       });
-      const fetchOptions = buildFetchOpts({context, contextOpts, actionOpts});
+      const fetchOptions = buildFetchOpts({context, contextOpts, actionOpts: Object.assign({}, actionOpts, dynamicOpts)});
       // d(`${name}Actions.${actionName}()`, fetchUrl, fetchOptions);
       return fetch(fetchUrl, fetchOptions)
         .then(applyTransformPipeline(buildTransformPipeline(defaultTransformResponsePipeline, actionOpts.transformResponse)))


### PR DESCRIPTION
Bugfix for the feature I built in #12:

What happened is that if you passed a function as any of the actionOpts parameters this function would only be evaluated once and the result would be cached for subsequent requests, which defeats the whole purpose of being able to determine the actionOpts based on redux state.

Attached is a bugfix and a regression test.