### PR TITLE
feat(actions): handle assignResponse in contextOpts

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -38,11 +38,12 @@ const createActions = ({name, pluralName, url: defaultUrl, actions = {}, credent
         }
       });
       const fetchOptions = buildFetchOpts({context, contextOpts, actionOpts: Object.assign({}, actionOpts, dynamicOpts)});
+      const options = {...reducerOpts, ...pick(contextOpts, 'assignResponse')};
       // d(`${name}Actions.${actionName}()`, fetchUrl, fetchOptions);
       return fetch(fetchUrl, fetchOptions)
         .then(applyTransformPipeline(buildTransformPipeline(defaultTransformResponsePipeline, actionOpts.transformResponse)))
         .then(payload =>
-          dispatch({type, status: 'resolved', context, options: reducerOpts, receivedAt: Date.now(), ...payload}))
+          dispatch({type, status: 'resolved', context, options, receivedAt: Date.now(), ...payload}))
         .catch((err) => {
           // Catch HttpErrors
           if (err.statusCode) {
@@ -52,7 +53,7 @@ const createActions = ({name, pluralName, url: defaultUrl, actions = {}, credent
               code: err.statusCode,
               body: err.body,
               context,
-              options: reducerOpts,
+              options,
               receivedAt: Date.now()
             });
           // Catch regular Errors

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -7,7 +7,7 @@ export const isObject = maybeObject =>
 
 export const pick = (obj, ...keys) =>
   keys.reduce((soFar, key) => {
-    if (includes(keys, key) && obj[key]) {
+    if (includes(keys, key) && obj[key] !== undefined) {
       soFar[key] = obj[key]; // eslint-disable-line no-param-reassign
     }
     return soFar;

--- a/test/spec/actions.spec.js
+++ b/test/spec/actions.spec.js
@@ -310,6 +310,31 @@ describe('actionOptions', () => {
       .then(done)
       .catch(done);
   });
+  it('should handle `assignResponse` option', () => {
+    // @TODO test default option
+    const resource = createResource({name, url, actions: {...defaultActions}});
+    const actionFuncs = resource.actions;
+    const actionKey = 'get';
+    const action = getActionName({name, actionKey, actionOpts: {isArray: false}});
+    const type = getActionType({name, actionKey});
+    const context = {id: 1};
+    const body = {id: 1, firstName: 'Olivier'};
+    const code = 200;
+    const options = {assignResponse: true};
+    nock(host, {}).get('/users/1')
+      .reply(code, body);
+    const store = mockStore({users: {}});
+    const expectedActions = [
+      {status: 'pending', type, context},
+      {status: 'resolved', type, context, options, body, code, receivedAt: null}
+    ];
+    return store.dispatch(actionFuncs[action](context, {assignResponse: true}))
+      .then(() => {
+        const actions = store.getActions();
+        actions[1].receivedAt = null;
+        expect(actions).toEqual(expectedActions);
+      });
+  });
   it('should allow `url` to be a function', () => {
     const urlDependingOnState = getState => `${host}/community/${getState().users.community}/users/:id`;
     const resource = createResource({name, url: urlDependingOnState});


### PR DESCRIPTION
We can override assignResponse option in action context options.