### PR TITLE
Also parse +json suffix content-type as JSON

### DIFF
--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -1,4 +1,4 @@
-import {isObject, isString, startsWith} from './util';
+import {isObject, isString, startsWith, endsWith} from './util';
 import {
   encodeUriQuery,
   encodeUriSegment,
@@ -82,7 +82,14 @@ const fetch = (url, options = {}) => {
     .then((res) => {
       if (!res.ok) {
         const contentType = res.headers.get('Content-Type');
-        const isJson = startsWith(contentType, 'application/json');
+
+        const isApplicationJson = startsWith(contentType, 'application/json');
+
+        // https://tools.ietf.org/html/rfc6839
+        // parses 'application/problem+json; charset=utf-8' for example
+        const isJsonSubtypeBySuffix = endsWith(contentType.split(';')[0], '+json');
+
+        const isJson = isApplicationJson || isJsonSubtypeBySuffix;
         return res[isJson ? 'json' : 'text']().then((body) => {
           throw new HttpError(res.status, {body});
         });

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -38,6 +38,9 @@ export const mergeObjects = (object, ...sources) => {
 export const startsWith = (string, target) =>
   String(string).slice(0, target.length) === target;
 
+export const endsWith = (string, target) =>
+  String(string).slice(string.length - target.length) === target;
+
 export const ucfirst = str =>
   str.charAt(0).toUpperCase() + str.substr(1);
 


### PR DESCRIPTION
We're using redux-rest-resource to consume API responses that conform with https://tools.ietf.org/html/rfc7807 .. they don't come as `Content-Type: application/json` but as `Content-Type: application/problem+json; charset=utf-8`.

This teaches redux-rest-resource to also parse those as JSON.