### PR TITLE
mergeArray option for FETCH action

### DIFF
--- a/docs/basics/Actions.md
+++ b/docs/basics/Actions.md
@@ -95,11 +95,11 @@ actions.updateUser({
 
 #### Reduce related options
 
-| Option name      | Type                | Default    | Description                               |
-|------------------|---------------------|------------|-------------------------------------------|
-| `isArray`        | *Boolean*           | false      | Whether the expected response is an Array |
-| `assignResponse` | *Boolean*           | false      | Whether to assign the response            |
-
+| Option name      | Type                | Default    | Description                                         |
+|------------------|---------------------|------------|-----------------------------------------------------|
+| `isArray`        | *Boolean*           | false      | Whether the expected response is an Array           |
+| `assignResponse` | *Boolean*           | false      | Whether to assign the response                      |
+| `mergeArray`     | *Boolean*           | false      | Whether to merge the response with items FETCH prop |
 
 ### Dispatched actions
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,7 +8,7 @@ import {isFunction, isString, pick, ucfirst, getPluralName} from './../helpers/u
 import {defaultTransformResponsePipeline} from './../defaults';
 
 const SUPPORTED_FETCH_OPTS = ['url', 'method', 'headers', 'credentials', 'query', 'body'];
-const SUPPORTED_REDUCE_OPTS = ['assignResponse', 'isArray', 'isPure'];
+const SUPPORTED_REDUCE_OPTS = ['assignResponse', 'isArray', 'isPure', 'mergeArray'];
 
 const getActionName = (actionId, {resourceName, resourcePluralName = getPluralName(resourceName), isArray = false} = {}) => (
   !resourceName

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -36,10 +36,12 @@ const defaultReducers = {
           didInvalidate: false
         };
       case 'resolved':
+        const actionOpts = action.options || {};
+        const items = action.body;
         return {...state,
           isFetching: false,
           didInvalidate: false,
-          items: action.body,
+          items: actionOpts.mergeArray ? {...state.items, ...items} : items,
           lastUpdated: action.receivedAt
         };
       case 'rejected':

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,4 @@
-import {unionBy} from 'lodash';
+import {unionBy, sortBy} from 'lodash';
 import {initialState} from './../defaults';
 import {getTypesScope, getActionType} from './../types';
 import {getGerundName, isFunction, ucfirst} from './../helpers/util';
@@ -42,7 +42,7 @@ const defaultReducers = {
         return {...state,
           isFetching: false,
           didInvalidate: false,
-          items: actionOpts.mergeArray ? unionBy(items, state.items, 'id') : items,
+          items: actionOpts.mergeArray ? sortBy(unionBy(items, state.items, 'id'), 'id') : items,
           lastUpdated: action.receivedAt
         };
       }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,3 +1,4 @@
+import {unionBy} from 'lodash';
 import {initialState} from './../defaults';
 import {getTypesScope, getActionType} from './../types';
 import {getGerundName, isFunction, ucfirst} from './../helpers/util';
@@ -35,15 +36,16 @@ const defaultReducers = {
           isFetching: true,
           didInvalidate: false
         };
-      case 'resolved':
+      case 'resolved': {
         const actionOpts = action.options || {};
         const items = action.body;
         return {...state,
           isFetching: false,
           didInvalidate: false,
-          items: actionOpts.mergeArray ? {...state.items, ...items} : items,
+          items: actionOpts.mergeArray ? unionBy(items, state.items, 'id') : items,
           lastUpdated: action.receivedAt
         };
+      }
       case 'rejected':
         return {...state,
           isFetching: false,


### PR DESCRIPTION
I added this option to deal with HTTP range requests for pagination. If `mergeArray` is `true`, response is merged with `items` property in the FETCH part of the state.