### PR TITLE
Fixed the plural name when ends with a 's'

### DIFF
--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -53,5 +53,5 @@ export const upperSnakeCase = string =>
 export const getGerundName = name =>
   `${name.replace(/e$/, '')}ing`;
 
-export const getPluralName = name =>
-  `${name}s`;
+export const getPluralName = (name = '') =>
+  (name.endsWith('s') ? name : `${name}s`);


### PR DESCRIPTION
```
export const { types, actions, rootReducer } = createResource({
  name: 'status',
  url: `${baseURL}/status`
})
```
A resource named `status` was generating a `fetchStatuss` action. Now it generates a `fetchStatus` action.