### PR TITLE
Add support for multiple updates and deletes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8332 @@
+{
+  "name": "redux-rest-resource",
+  "version": "0.18.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.44"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "3.1.0",
+        "globals": "11.5.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.5.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+      "dev": true
+    },
+    "acorn-globals": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.7.1"
+      }
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
+    },
+    "append-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "2.0.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "aria-query": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
+      "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "2.15.1"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true,
+      "optional": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
+    },
+    "axobject-query": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
+      "integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
+    "babel-cli": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.3",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.15.1",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "babel-eslint": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
+      "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+      "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "esutils": "2.0.2"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-jest": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+      "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-istanbul": "4.1.6",
+        "babel-preset-jest": "22.4.4"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "test-exclude": "4.2.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+      "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-function-bind": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+      "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
+      "dev": true
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-function-bind": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
+      "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-function-bind": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-react-display-name": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-react-jsx": "6.26.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx-self": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.10.1"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.8",
+        "invariant": "2.2.4",
+        "semver": "5.5.0"
+      }
+    },
+    "babel-preset-flow": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-flow-strip-types": "6.22.0"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+      "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "22.4.4",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0"
+      }
+    },
+    "babel-preset-react": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.24.1",
+        "babel-plugin-transform-react-jsx-self": "6.22.0",
+        "babel-plugin-transform-react-jsx-source": "6.22.0",
+        "babel-preset-flow": "6.23.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "binary-extensions": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "dev": true,
+      "optional": true
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
+    },
+    "browser-resolve": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
+    "browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "1.0.30000856",
+        "electron-to-chromium": "1.3.48"
+      }
+    },
+    "bser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "dev": true,
+      "requires": {
+        "node-int64": "0.4.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000856",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
+      "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg==",
+      "dev": true
+    },
+    "capture-exit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+      "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+      "dev": true,
+      "requires": {
+        "rsvp": "3.6.2"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
+    },
+    "ci-info": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "codacy-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/codacy-coverage/-/codacy-coverage-3.0.0.tgz",
+      "integrity": "sha512-hQJIMhBM5JYeIpu9gKHRmIK5uj9zWDtWBDGtW7PnWRYHMr1Wp93B+l5s82d6XymFJDCZENSp0uWY9zfR1meBwQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "commander": "2.15.1",
+        "joi": "13.4.0",
+        "lcov-parse": "1.0.0",
+        "lodash": "4.17.10",
+        "log-driver": "1.2.7",
+        "request": "2.87.0",
+        "request-promise": "4.2.2"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "compare-versions": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
+      "integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.1.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
+      }
+    },
+    "cssom": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
+      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.2"
+      }
+    },
+    "damerau-levenshtein": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.5.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "debug-utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/debug-utils/-/debug-utils-0.3.2.tgz",
+      "integrity": "sha512-TnPwHSePcdPO84Gc6MB0pAe2DtGh2uHodOhG+BTSzHiKiVRC/p2eGCtRvztogAesIPbSYioCFznaE63V95++Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "3.0.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2"
+      }
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "4.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.48",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
+      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA=",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.23"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+      "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+      "dev": true,
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.1",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.5.0",
+        "ignore": "3.3.8",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.5.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-airbnb": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz",
+      "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "12.1.0"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
+      "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
+      "dev": true,
+      "requires": {
+        "eslint-restricted-globals": "0.1.1"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "resolve": "1.8.1"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz",
+      "integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
+      "dev": true,
+      "requires": {
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.2.0",
+        "has": "1.0.3",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.8.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
+      "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
+      "dev": true,
+      "requires": {
+        "aria-query": "0.7.1",
+        "array-includes": "3.0.3",
+        "ast-types-flow": "0.0.7",
+        "axobject-query": "0.1.0",
+        "damerau-levenshtein": "1.0.4",
+        "emoji-regex": "6.5.1",
+        "jsx-ast-utils": "2.0.1"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.9.1.tgz",
+      "integrity": "sha512-uvq+2ZkiqzjwF+pMZ8xqIC3pChV4KviPvvPIyQOvKWnjtvyW3iGfHIRqVumw05L3itby0QGmA4VdBA9m1OdMmg==",
+      "dev": true,
+      "requires": {
+        "doctrine": "2.1.0",
+        "has": "1.0.3",
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.1"
+      }
+    },
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.7.1",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "exec-sh": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+      "dev": true,
+      "requires": {
+        "merge": "1.2.0"
+      }
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.4"
+      }
+    },
+    "expect": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+      "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "jest-diff": "22.4.3",
+        "jest-get-type": "22.4.3",
+        "jest-matcher-utils": "22.4.3",
+        "jest-message-util": "22.4.3",
+        "jest-regex-util": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.23",
+        "tmp": "0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "requires": {
+        "bser": "2.0.0"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "filename-reserved-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "1.0.0",
+        "strip-outer": "1.0.1",
+        "trim-repeated": "1.0.0"
+      }
+    },
+    "filenamify-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
+      "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
+      "dev": true,
+      "requires": {
+        "filenamify": "1.2.1",
+        "humanize-url": "1.0.1"
+      }
+    },
+    "fileset": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "minimatch": "3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.0.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "gh-pages": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.2.0.tgz",
+      "integrity": "sha512-cGLYAvxtlQ1iTwAS4g7FreZPXoE/g62Fsxln2mmR19mgs4zZI+XJ+wVVUhBFCF/0+Nmvbq+abyTWue1m1BSnmg==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1",
+        "commander": "2.15.1",
+        "filenamify-url": "1.0.0",
+        "fs-extra": "5.0.0",
+        "globby": "6.1.0",
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "hoek": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+      "dev": true
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "1.0.3"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
+      }
+    },
+    "humanize-url": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
+      "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
+      "dev": true,
+      "requires": {
+        "normalize-url": "1.9.1",
+        "strip-url-auth": "1.0.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "ignore": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "dev": true
+    },
+    "import-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        }
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.10",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "binary-extensions": "1.11.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.3"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.3"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isemail": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
+      "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul-api": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
+      "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1",
+        "compare-versions": "3.3.0",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.2.1",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.4",
+        "istanbul-lib-source-maps": "1.2.5",
+        "istanbul-reports": "1.3.0",
+        "js-yaml": "3.12.0",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
+          "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          }
+        }
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+      "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
+      "integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
+      "dev": true,
+      "requires": {
+        "append-transform": "1.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+      "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.26.1",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "semver": "5.5.0"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
+      "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.5",
+        "supports-color": "3.2.3"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+      "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
+      "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "4.0.11"
+      }
+    },
+    "jest": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
+      "integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
+      "dev": true,
+      "requires": {
+        "import-local": "1.0.0",
+        "jest-cli": "22.4.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "jest-cli": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+          "integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "exit": "0.1.2",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "import-local": "1.0.0",
+            "is-ci": "1.1.0",
+            "istanbul-api": "1.3.1",
+            "istanbul-lib-coverage": "1.2.0",
+            "istanbul-lib-instrument": "1.10.1",
+            "istanbul-lib-source-maps": "1.2.3",
+            "jest-changed-files": "22.4.3",
+            "jest-config": "22.4.4",
+            "jest-environment-jsdom": "22.4.3",
+            "jest-get-type": "22.4.3",
+            "jest-haste-map": "22.4.3",
+            "jest-message-util": "22.4.3",
+            "jest-regex-util": "22.4.3",
+            "jest-resolve-dependencies": "22.4.3",
+            "jest-runner": "22.4.4",
+            "jest-runtime": "22.4.4",
+            "jest-snapshot": "22.4.3",
+            "jest-util": "22.4.3",
+            "jest-validate": "22.4.4",
+            "jest-worker": "22.4.3",
+            "micromatch": "2.3.11",
+            "node-notifier": "5.2.1",
+            "realpath-native": "1.0.0",
+            "rimraf": "2.6.2",
+            "slash": "1.0.0",
+            "string-length": "2.0.0",
+            "strip-ansi": "4.0.0",
+            "which": "1.3.1",
+            "yargs": "10.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
+      "integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+      "dev": true,
+      "requires": {
+        "throat": "4.1.0"
+      }
+    },
+    "jest-config": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+      "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "glob": "7.1.2",
+        "jest-environment-jsdom": "22.4.3",
+        "jest-environment-node": "22.4.3",
+        "jest-get-type": "22.4.3",
+        "jest-jasmine2": "22.4.4",
+        "jest-regex-util": "22.4.3",
+        "jest-resolve": "22.4.3",
+        "jest-util": "22.4.3",
+        "jest-validate": "22.4.4",
+        "pretty-format": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "diff": "3.5.0",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-docblock": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+      "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "2.1.0"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+      "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+      "dev": true,
+      "requires": {
+        "jest-mock": "22.4.3",
+        "jest-util": "22.4.3",
+        "jsdom": "11.11.0"
+      }
+    },
+    "jest-environment-node": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+      "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+      "dev": true,
+      "requires": {
+        "jest-mock": "22.4.3",
+        "jest-util": "22.4.3"
+      }
+    },
+    "jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
+      "integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+      "dev": true,
+      "requires": {
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-docblock": "22.4.3",
+        "jest-serializer": "22.4.3",
+        "jest-worker": "22.4.3",
+        "micromatch": "2.3.11",
+        "sane": "2.5.2"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+      "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "co": "4.6.0",
+        "expect": "22.4.3",
+        "graceful-fs": "4.1.11",
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "22.4.3",
+        "jest-matcher-utils": "22.4.3",
+        "jest-message-util": "22.4.3",
+        "jest-snapshot": "22.4.3",
+        "jest-util": "22.4.3",
+        "source-map-support": "0.5.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.1.0",
+            "source-map": "0.6.1"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-leak-detector": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+      "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "22.4.3"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+      "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+      "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "chalk": "2.4.1",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0",
+        "stack-utils": "1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+      "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+      "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+      "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+      "dev": true,
+      "requires": {
+        "browser-resolve": "1.11.2",
+        "chalk": "2.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+      "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "22.4.3"
+      }
+    },
+    "jest-runner": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+      "integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "jest-config": "22.4.4",
+        "jest-docblock": "22.4.3",
+        "jest-haste-map": "22.4.3",
+        "jest-jasmine2": "22.4.4",
+        "jest-leak-detector": "22.4.3",
+        "jest-message-util": "22.4.3",
+        "jest-runtime": "22.4.4",
+        "jest-util": "22.4.3",
+        "jest-worker": "22.4.3",
+        "throat": "4.1.0"
+      }
+    },
+    "jest-runtime": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+      "integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.3",
+        "babel-jest": "22.4.4",
+        "babel-plugin-istanbul": "4.1.6",
+        "chalk": "2.4.1",
+        "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.11",
+        "jest-config": "22.4.4",
+        "jest-haste-map": "22.4.3",
+        "jest-regex-util": "22.4.3",
+        "jest-resolve": "22.4.3",
+        "jest-util": "22.4.3",
+        "jest-validate": "22.4.4",
+        "json-stable-stringify": "1.0.1",
+        "micromatch": "2.3.11",
+        "realpath-native": "1.0.0",
+        "slash": "1.0.0",
+        "strip-bom": "3.0.0",
+        "write-file-atomic": "2.3.0",
+        "yargs": "10.1.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-serializer": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
+      "integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+      "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "jest-diff": "22.4.3",
+        "jest-matcher-utils": "22.4.3",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "pretty-format": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-util": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+      "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+      "dev": true,
+      "requires": {
+        "callsites": "2.0.0",
+        "chalk": "2.4.1",
+        "graceful-fs": "4.1.11",
+        "is-ci": "1.1.0",
+        "jest-message-util": "22.4.3",
+        "mkdirp": "0.5.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+      "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "jest-config": "22.4.4",
+        "jest-get-type": "22.4.3",
+        "leven": "2.1.0",
+        "pretty-format": "22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "jest-worker": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+      "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "1.0.1"
+      }
+    },
+    "joi": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.4.0.tgz",
+      "integrity": "sha512-JuK4GjEu6j7zr9FuVe2MAseZ6si/8/HaY0qMAejfDFHp7jcH4OKE937mIHM5VT4xDS0q7lpQbszbxKV9rm0yUg==",
+      "dev": true,
+      "requires": {
+        "hoek": "5.0.3",
+        "isemail": "3.1.2",
+        "topo": "3.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jsdom": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
+      "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "acorn": "5.7.1",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "cssom": "0.3.2",
+        "cssstyle": "0.3.1",
+        "data-urls": "1.0.0",
+        "domexception": "1.0.1",
+        "escodegen": "1.10.0",
+        "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.3.0",
+        "nwsapi": "2.0.3",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
+        "request": "2.87.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.4",
+        "w3c-hr-time": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.5.0",
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "dev": true,
+      "requires": {
+        "array-includes": "3.0.3"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.4"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.6"
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nock": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.3.3.tgz",
+      "integrity": "sha512-FBgnx25er2ly7KBr0Est5F0z5g+lnyr6a72vZI1KMi7nTL4ojU6XpFhlrfw6CXRdnT2FA5i8exHiT1uVNUM1qA==",
+      "dev": true,
+      "requires": {
+        "chai": "4.1.2",
+        "debug": "3.1.0",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "propagate": "1.0.0",
+        "qs": "6.5.2",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node-notifier": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+      "dev": true,
+      "requires": {
+        "growly": "1.3.0",
+        "semver": "5.5.0",
+        "shellwords": "0.1.1",
+        "which": "1.3.1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nwsapi": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.3.tgz",
+      "integrity": "sha512-zFJF9lOpg2+uicP0BQKOAfIOqeTp/p8PC669mewxgRkR1hGjne8BMUHk4wpRS9o5Z0icA5Nv04HmGkW31KfMKw==",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0"
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.3.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "parse5": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
+      "integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+      "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        }
+      }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.17",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
+    },
+    "randomatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
+    "realpath-native": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+      "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+      "dev": true,
+      "requires": {
+        "util.promisify": "1.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.2.0"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.3.tgz",
+      "integrity": "sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "4.0.6"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==",
+      "dev": true
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sane": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+      "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+      "dev": true,
+      "requires": {
+        "anymatch": "2.0.0",
+        "capture-exit": "1.2.0",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "2.0.0",
+        "fsevents": "1.2.4",
+        "micromatch": "3.1.10",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.18.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true,
+      "optional": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
+    "string-length": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "dev": true,
+      "requires": {
+        "astral-regex": "1.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "strip-url-auth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
+      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
+    },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.4.1",
+        "lodash": "4.17.10",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "test-exclude": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+      "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "3.1.10",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "require-main-filename": "1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        }
+      }
+    },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "dev": true,
+      "requires": {
+        "hoek": "5.0.3"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.1"
+      }
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
+      }
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "0.1.2"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.11"
+      }
+    },
+    "watch": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "0.2.1",
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        }
+      }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
+    },
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "ws": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+      "dev": true,
+      "requires": {
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "8.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+      "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
+    }
+  }
+}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -55,10 +55,10 @@ const createAction = (
     const resolvedfetchOpts = Object.keys(fetchOpts).reduce((soFar, key) => {
       soFar[key] = isFunction(fetchOpts[key])
         ? fetchOpts[key](getState, {
-          context,
-          contextOpts,
-          actionId
-        })
+            context,
+            contextOpts,
+            actionId
+          })
         : fetchOpts[key];
       return soFar;
     }, {});

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -12,8 +12,8 @@ const SUPPORTED_REDUCE_OPTS = ['assignResponse', 'isArray', 'isPure'];
 
 const getActionName = (
   actionId,
-  {resourceName, resourcePluralName = getPluralName(resourceName), isArray = false} = {}
-) => (!resourceName ? actionId : `${actionId}${ucfirst(isArray ? resourcePluralName : resourceName)}`);
+  {resourceName, resourcePluralName = getPluralName(resourceName), isArray = false, alias} = {}
+) => (!resourceName ? actionId : `${alias || actionId}${ucfirst(isArray ? resourcePluralName : resourceName)}`);
 
 const createAction = (
   actionId,
@@ -32,11 +32,20 @@ const createAction = (
     };
     // Support pure actions
     if (actionOpts.isPure) {
-      dispatch({type, status: 'resolved', options: reduceOpts, context});
+      dispatch({
+        type,
+        status: 'resolved',
+        options: reduceOpts,
+        context
+      });
       return Promise.resolve();
     }
     // First dispatch a pending action
-    dispatch({type, status: 'pending', context});
+    dispatch({
+      type,
+      status: 'pending',
+      context
+    });
     // Prepare fetch options
     const fetchOpts = {
       ...pick(actionOpts, ...SUPPORTED_FETCH_OPTS),
@@ -45,21 +54,36 @@ const createAction = (
     // Support dynamic fetch options
     const resolvedfetchOpts = Object.keys(fetchOpts).reduce((soFar, key) => {
       soFar[key] = isFunction(fetchOpts[key])
-        ? fetchOpts[key](getState, {context, contextOpts, actionId})
+        ? fetchOpts[key](getState, {
+          context,
+          contextOpts,
+          actionId
+        })
         : fetchOpts[key];
       return soFar;
     }, {});
     const {url, ...eligibleFetchOptions} = resolvedfetchOpts;
     // Build fetch url and options
     const urlParams = parseUrlParams(url);
-    const finalFetchUrl = buildFetchUrl(context, {url, urlParams});
+    const finalFetchUrl = buildFetchUrl(context, {
+      url,
+      urlParams,
+      isArray: reduceOpts.isArray
+    });
     const finalFetchOpts = buildFetchOpts(context, eligibleFetchOptions);
     return fetch(finalFetchUrl, finalFetchOpts)
       .then(
         applyTransformPipeline(buildTransformPipeline(defaultTransformResponsePipeline, actionOpts.transformResponse))
       )
       .then(payload =>
-        dispatch({type, status: 'resolved', context, options: reduceOpts, receivedAt: Date.now(), ...payload})
+        dispatch({
+          type,
+          status: 'resolved',
+          context,
+          options: reduceOpts,
+          receivedAt: Date.now(),
+          ...payload
+        })
       ) // eslint-disable-line
       .catch(err => {
         // Catch HttpErrors
@@ -102,12 +126,29 @@ const createActions = (
   return actionKeys.reduce((actionFuncs, actionId) => {
     // Add support for relative url override
     const {url} = actions[actionId];
+
     if (globalOpts.url && url && isString(url) && url.substr(0, 1) === '.') {
-      actions[actionId] = {...actions[actionId], url: `${globalOpts.url}${url.substr(1)}`};
+      actions[actionId] = {
+        ...actions[actionId],
+        url: `${globalOpts.url}${url.substr(1)}`
+      };
     }
-    const actionOpts = {...globalOpts, ...actions[actionId]};
-    const actionName = getActionName(actionId, {resourceName, resourcePluralName, isArray: actionOpts.isArray});
-    actionFuncs[actionName] = createAction(actionId, {resourceName, resourcePluralName, scope, ...actionOpts});
+    const actionOpts = {
+      ...globalOpts,
+      ...actions[actionId]
+    };
+    const actionName = getActionName(actionId, {
+      resourceName,
+      resourcePluralName,
+      isArray: actionOpts.isArray,
+      alias: actionOpts.alias
+    });
+    actionFuncs[actionName] = createAction(actionId, {
+      resourceName,
+      resourcePluralName,
+      scope,
+      ...actionOpts
+    });
     return actionFuncs;
   }, {});
 };

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -4,10 +4,11 @@ import {parseResponse} from './../helpers/fetch';
 import {parseContentRangeHeader} from './../helpers/util';
 
 const defaultActions = {
-  create: {method: 'POST', alias: 'save'},
+  create: {method: 'POST'},
   fetch: {method: 'GET', isArray: true},
   get: {method: 'GET'},
   update: {method: 'PATCH'},
+  updateArray: {method: 'PATCH', isArray: true, alias: 'update'},
   delete: {method: 'DELETE'}
 };
 

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -9,7 +9,8 @@ const defaultActions = {
   get: {method: 'GET'},
   update: {method: 'PATCH'},
   updateArray: {method: 'PATCH', isArray: true, alias: 'update'},
-  delete: {method: 'DELETE'}
+  delete: {method: 'DELETE'},
+  deleteArray: {method: 'DELETE', isArray: true, alias: 'delete'}
 };
 
 const defaultHeaders = {

--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -30,7 +30,11 @@ export const buildFetchUrl = (context, {url, urlParams, stripTrailingSlashes = t
   // Replace urlParams with values from context
   let builtUrl = Object.keys(urlParams).reduce((wipUrl, urlParam) => {
     const urlParamInfo = urlParams[urlParam];
-    const contextAsObject = !isObject(context) ? {id: context} : context;
+    const contextAsObject = !isObject(context)
+      ? {
+        id: context
+      }
+      : context;
     const value = contextAsObject[urlParam] || ''; // self.defaults[urlParam];
     if (value) {
       const encodedValue = urlParamInfo.isQueryParamValue ? encodeUriQuery(value, true) : encodeUriSegment(value);
@@ -53,7 +57,10 @@ export const buildFetchOpts = (context, {method, headers, credentials, query, bo
     opts.method = method;
   }
   if (headers) {
-    opts.headers = {...opts.headers, ...headers};
+    opts.headers = {
+      ...opts.headers,
+      ...headers
+    };
   }
   if (credentials) {
     opts.credentials = credentials;
@@ -94,7 +101,9 @@ const fetch = (url, options = {}) => {
     .then(res => {
       if (!res.ok) {
         return parseResponse(res).then(body => {
-          throw new HttpError(res.status, {body});
+          throw new HttpError(res.status, {
+            body
+          });
         });
       }
       return res;

--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -32,8 +32,8 @@ export const buildFetchUrl = (context, {url, urlParams, stripTrailingSlashes = t
     const urlParamInfo = urlParams[urlParam];
     const contextAsObject = !isObject(context)
       ? {
-        id: context
-      }
+          id: context
+        }
       : context;
     const value = contextAsObject[urlParam] || ''; // self.defaults[urlParam];
     if (value) {

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -14,6 +14,19 @@ export const pick = (obj, ...keys) =>
     return soFar;
   }, {});
 
+export const find = (collection, query) => {
+  const queryKeys = Object.keys(query);
+  let foundItem;
+  collection.some(item => {
+    const doesMatch = !queryKeys.some(key => item[key] !== queryKeys[key]);
+    if (doesMatch) {
+      foundItem = item;
+    }
+    return doesMatch;
+  });
+  return foundItem;
+};
+
 export const mapObject = (object, func) =>
   Object.keys(object).reduce((soFar, key) => {
     soFar[key] = func(object[key]); // eslint-disable-line no-param-reassign

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -77,3 +77,5 @@ export const parseContentRangeHeader = string => {
   }
   return null;
 };
+
+export const getIdKey = (action, {multi = false}) => multi ? 'ids' : 'id';

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -18,7 +18,7 @@ export const find = (collection, query) => {
   const queryKeys = Object.keys(query);
   let foundItem;
   collection.some(item => {
-    const doesMatch = !queryKeys.some(key => item[key] !== queryKeys[key]);
+    const doesMatch = !queryKeys.some(key => item[key] !== query[key]);
     if (doesMatch) {
       foundItem = item;
     }

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -78,4 +78,4 @@ export const parseContentRangeHeader = string => {
   return null;
 };
 
-export const getIdKey = (action, {multi = false}) => multi ? 'ids' : 'id';
+export const getIdKey = (action, {multi = false}) => (multi ? 'ids' : 'id');

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -251,6 +251,43 @@ const defaultReducers = {
       default:
         return state;
     }
+  },
+  deleteArray: (state, action) => {
+    switch (action.status) {
+      case 'pending':
+        // Update object in store as soon as possible?
+        return {
+          ...state,
+          isArrayDeleting: true
+        };
+      case 'resolved': // eslint-disable-line
+        const actionOpts = action.options || {};
+        const idKey = getIdKey(action, {multi: false});
+        const idKeyMulti = getIdKey(action, {multi: true});
+        const {[idKeyMulti]: ids} = actionOpts.query || action.context;
+
+        if (!ids) {
+          return {
+            ...state,
+            isArrayDeleting: false,
+            items: [],
+            item: null
+          };
+        }
+        return {
+          ...state,
+          isArrayDeleting: false,
+          items: [...state.items.filter(el => !ids.includes(el[idKey]))],
+          item: ids.includes(state.item[idKey]) ? null : state.item
+        };
+      case 'rejected':
+        return {
+          ...state,
+          isArrayDeleting: false
+        };
+      default:
+        return state;
+    }
   }
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,14 +8,14 @@ const getUpdateArrayData = (action, itemId) => {
 
   return actionOpts.assignResponse
     ? find(action.body, {
-      [idKey]: itemId
-    })
+        [idKey]: itemId
+      })
     : Object.keys(action.context).reduce((soFar, key) => {
-      if (key !== 'ids') {
-        soFar[key] = action.context[key];
-      }
-      return soFar;
-    }, {});
+        if (key !== 'ids') {
+          soFar[key] = action.context[key];
+        }
+        return soFar;
+      }, {});
 };
 
 const defaultReducers = {
@@ -156,9 +156,9 @@ const defaultReducers = {
         const updatedItem =
           state.item && state.item[idKey] === id
             ? {
-              ...state.item,
-              ...update
-            }
+                ...state.item,
+                ...update
+              }
             : state.item;
         return {
           ...state,
@@ -196,9 +196,9 @@ const defaultReducers = {
             const updatedItem = getUpdateArrayData(action, item[idKey]);
             return updatedItem
               ? {
-                ...item,
-                ...updatedItem
-              }
+                  ...item,
+                  ...updatedItem
+                }
               : item;
           }
           return item;
@@ -207,9 +207,9 @@ const defaultReducers = {
         const updatedItem =
           state.item && (!ids || ids.includes(state.item[idKey]))
             ? {
-              ...state.item,
-              ...getUpdateArrayData(action, state.item[idKey])
-            }
+                ...state.item,
+                ...getUpdateArrayData(action, state.item[idKey])
+              }
             : state.item;
         return {
           ...state,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -182,7 +182,7 @@ const defaultReducers = {
         // Update object in store as soon as possible?
         return {
           ...state,
-          isBatchUpdating: true
+          isUpdatingArray: true
         };
       case 'resolved': {
         // Assign context or returned object
@@ -213,7 +213,7 @@ const defaultReducers = {
             : state.item;
         return {
           ...state,
-          isBatchUpdating: false,
+          isUpdatingArray: false,
           items: updatedItems,
           item: updatedItem
         };
@@ -221,7 +221,7 @@ const defaultReducers = {
       case 'rejected':
         return {
           ...state,
-          isBatchUpdating: false
+          isUpdatingArray: false
         };
       default:
         return state;

--- a/src/types.js
+++ b/src/types.js
@@ -1,4 +1,8 @@
-import {mapObject, getPluralName, upperSnakeCase} from './helpers/util';
+import {
+  mapObject,
+  getPluralName,
+  upperSnakeCase
+} from './helpers/util';
 
 const scopeType = (type, scope) => (scope ? `${scope}/${type}` : type);
 
@@ -7,26 +11,57 @@ const scopeTypes = (types = {}, scope) => (scope ? mapObject(types, type => scop
 const getTypesScope = resourceName => (resourceName ? `@@resource/${upperSnakeCase(resourceName)}` : '');
 
 const getActionTypeKey = (
-  actionId,
-  {resourceName, resourcePluralName = getPluralName(resourceName), isArray = false} = {}
+  actionId, {
+    resourceName,
+    resourcePluralName = getPluralName(resourceName),
+    isArray = false
+  } = {}
 ) =>
-  resourceName
-    ? `${actionId.toUpperCase()}_${upperSnakeCase(isArray ? resourcePluralName : resourceName)}`
-    : upperSnakeCase(actionId);
+  resourceName ?
+    `${actionId.toUpperCase()}_${upperSnakeCase(isArray ? resourcePluralName : resourceName)}` :
+    upperSnakeCase(actionId);
 
 const getActionType = actionId => upperSnakeCase(actionId);
 
-const createType = (actionId, {resourceName, resourcePluralName, isArray = false}) => {
-  const typeKey = getActionTypeKey(actionId, {resourceName, resourcePluralName, isArray});
-  return {[typeKey]: getActionType(actionId)};
+const createType = (actionId, {
+  resourceName,
+  resourcePluralName,
+  isArray = false,
+  alias
+}) => {
+  const typeKey = getActionTypeKey(resourceName ? (alias || actionId) : actionId, {
+    resourceName,
+    resourcePluralName,
+    isArray
+  });
+  return {
+    [typeKey]: getActionType(actionId)
+  };
 };
 
-const createTypes = (actions = {}, {resourceName, resourcePluralName, scope = getTypesScope(resourceName)} = {}) => {
+const createTypes = (actions = {}, {
+  resourceName,
+  resourcePluralName,
+  scope = getTypesScope(resourceName)
+} = {}) => {
   const rawTypes = Object.keys(actions).reduce((types, actionId) => {
     const actionOpts = actions[actionId];
-    return Object.assign(types, createType(actionId, {resourceName, resourcePluralName, isArray: actionOpts.isArray}));
+    return Object.assign(types, createType(actionId, {
+      resourceName,
+      resourcePluralName,
+      isArray: actionOpts.isArray,
+      alias: actionOpts.alias
+    }));
   }, {});
   return scopeTypes(rawTypes, scope);
 };
 
-export {scopeType, scopeTypes, getTypesScope, createType, createTypes, getActionType, getActionTypeKey};
+export {
+  scopeType,
+  scopeTypes,
+  getTypesScope,
+  createType,
+  createTypes,
+  getActionType,
+  getActionTypeKey
+};

--- a/src/types.js
+++ b/src/types.js
@@ -1,8 +1,4 @@
-import {
-  mapObject,
-  getPluralName,
-  upperSnakeCase
-} from './helpers/util';
+import {mapObject, getPluralName, upperSnakeCase} from './helpers/util';
 
 const scopeType = (type, scope) => (scope ? `${scope}/${type}` : type);
 
@@ -11,25 +7,17 @@ const scopeTypes = (types = {}, scope) => (scope ? mapObject(types, type => scop
 const getTypesScope = resourceName => (resourceName ? `@@resource/${upperSnakeCase(resourceName)}` : '');
 
 const getActionTypeKey = (
-  actionId, {
-    resourceName,
-    resourcePluralName = getPluralName(resourceName),
-    isArray = false
-  } = {}
+  actionId,
+  {resourceName, resourcePluralName = getPluralName(resourceName), isArray = false} = {}
 ) =>
-  resourceName ?
-    `${actionId.toUpperCase()}_${upperSnakeCase(isArray ? resourcePluralName : resourceName)}` :
-    upperSnakeCase(actionId);
+  resourceName
+    ? `${actionId.toUpperCase()}_${upperSnakeCase(isArray ? resourcePluralName : resourceName)}`
+    : upperSnakeCase(actionId);
 
 const getActionType = actionId => upperSnakeCase(actionId);
 
-const createType = (actionId, {
-  resourceName,
-  resourcePluralName,
-  isArray = false,
-  alias
-}) => {
-  const typeKey = getActionTypeKey(resourceName ? (alias || actionId) : actionId, {
+const createType = (actionId, {resourceName, resourcePluralName, isArray = false, alias}) => {
+  const typeKey = getActionTypeKey(resourceName ? alias || actionId : actionId, {
     resourceName,
     resourcePluralName,
     isArray
@@ -39,29 +27,20 @@ const createType = (actionId, {
   };
 };
 
-const createTypes = (actions = {}, {
-  resourceName,
-  resourcePluralName,
-  scope = getTypesScope(resourceName)
-} = {}) => {
+const createTypes = (actions = {}, {resourceName, resourcePluralName, scope = getTypesScope(resourceName)} = {}) => {
   const rawTypes = Object.keys(actions).reduce((types, actionId) => {
     const actionOpts = actions[actionId];
-    return Object.assign(types, createType(actionId, {
-      resourceName,
-      resourcePluralName,
-      isArray: actionOpts.isArray,
-      alias: actionOpts.alias
-    }));
+    return Object.assign(
+      types,
+      createType(actionId, {
+        resourceName,
+        resourcePluralName,
+        isArray: actionOpts.isArray,
+        alias: actionOpts.alias
+      })
+    );
   }, {});
   return scopeTypes(rawTypes, scope);
 };
 
-export {
-  scopeType,
-  scopeTypes,
-  getTypesScope,
-  createType,
-  createTypes,
-  getActionType,
-  getActionTypeKey
-};
+export {scopeType, scopeTypes, getTypesScope, createType, createTypes, getActionType, getActionTypeKey};

--- a/test/spec/actions.spec.js
+++ b/test/spec/actions.spec.js
@@ -1,11 +1,19 @@
-import {values} from 'lodash';
+import {
+  values
+} from 'lodash';
 import configureMockStore from 'redux-mock-store';
 import expect from 'expect';
 import nock from 'nock';
 import thunk from 'redux-thunk';
 
-import {defaultActions, defaultHeaders} from '../../src';
-import {createActions, getActionName} from '../../src/actions';
+import {
+  defaultActions,
+  defaultHeaders
+} from '../../src';
+import {
+  createActions,
+  getActionName
+} from '../../src/actions';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -18,24 +26,35 @@ const url = `${host}/users/:id`;
 describe('createActions', () => {
   describe('when using a resource', () => {
     it('should return an object with properly named keys', () => {
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
-      const expectedKeys = ['createUser', 'fetchUsers', 'getUser', 'updateUser', 'deleteUser'];
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
+      const expectedKeys = ['createUser', 'fetchUsers', 'getUser', 'updateUser', 'updateUsers', 'deleteUser'];
       expect(Object.keys(actionFuncs)).toEqual(expectedKeys);
     });
     it('should return an object with properly typed values', () => {
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const expectedValuesFn = action => expect(typeof action).toBe('function');
       values(actionFuncs).forEach(expectedValuesFn);
     });
   });
   describe('when not using a resource', () => {
     it('should return an object with properly named keys', () => {
-      const actionFuncs = createActions(defaultActions, {url});
-      const expectedKeys = ['create', 'fetch', 'get', 'update', 'delete'];
+      const actionFuncs = createActions(defaultActions, {
+        url
+      });
+      const expectedKeys = ['create', 'fetch', 'get', 'update', 'updateArray', 'delete'];
       expect(Object.keys(actionFuncs)).toEqual(expectedKeys);
     });
     it('should return an object with properly typed values', () => {
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const expectedValuesFn = action => expect(typeof action).toBe('function');
       values(actionFuncs).forEach(expectedValuesFn);
     });
@@ -46,24 +65,46 @@ describe('defaultActions', () => {
   afterEach(() => {
     nock.cleanAll();
   });
-  const actionFuncs = createActions(defaultActions, {resourceName, url});
+  const actionFuncs = createActions(defaultActions, {
+    resourceName,
+    url
+  });
 
   describe('crudOperations', () => {
     it('.create()', () => {
       const actionId = 'create';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/CREATE';
-      const context = {firstName: 'Olivier'};
-      const body = {ok: true};
+      const context = {
+        firstName: 'Olivier'
+      };
+      const body = {
+        ok: true
+      };
       const code = 200;
       const options = {};
       nock(host)
         .post('/users', context)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(res => {
         res.receivedAt = null;
@@ -75,19 +116,40 @@ describe('defaultActions', () => {
     });
     it('.fetch()', () => {
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(res => {
         res.receivedAt = null;
@@ -99,19 +161,39 @@ describe('defaultActions', () => {
     });
     it('.get()', () => {
       const actionId = 'get';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/GET';
-      const context = {id: 1};
-      const body = {id: 1, firstName: 'Olivier'};
+      const context = {
+        id: 1
+      };
+      const body = {
+        id: 1,
+        firstName: 'Olivier'
+      };
       const code = 200;
       const options = {};
       nock(host)
         .get(`/users/${context.id}`)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(res => {
         res.receivedAt = null;
@@ -123,19 +205,39 @@ describe('defaultActions', () => {
     });
     it('.update()', () => {
       const actionId = 'update';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/UPDATE';
-      const context = {id: 1, firstName: 'Olivier'};
-      const body = {ok: true};
+      const context = {
+        id: 1,
+        firstName: 'Olivier'
+      };
+      const body = {
+        ok: true
+      };
       const code = 200;
       const options = {};
       nock(host)
         .patch(`/users/${context.id}`, context)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(res => {
         res.receivedAt = null;
@@ -147,19 +249,38 @@ describe('defaultActions', () => {
     });
     it('.delete()', () => {
       const actionId = 'delete';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/DELETE';
-      const context = {id: 1};
-      const body = {ok: true};
+      const context = {
+        id: 1
+      };
+      const body = {
+        ok: true
+      };
       const code = 200;
       const options = {};
       nock(host)
         .delete(`/users/${context.id}`)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(res => {
         res.receivedAt = null;
@@ -174,19 +295,41 @@ describe('defaultActions', () => {
   describe('exoticResponses', () => {
     it('.fetch() with an exotic json Content-Type', () => {
       const actionId = 'get';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/GET';
-      const context = {id: 1};
-      const body = {id: 1, firstName: 'Olivier'};
+      const context = {
+        id: 1
+      };
+      const body = {
+        id: 1,
+        firstName: 'Olivier'
+      };
       const code = 200;
       const options = {};
       nock(host)
         .get(`/users/${context.id}`)
-        .reply(code, body, {'Content-Type': 'application/problem+json; charset=utf-8'});
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+        .reply(code, body, {
+          'Content-Type': 'application/problem+json; charset=utf-8'
+        });
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(res => {
         res.receivedAt = null;
@@ -198,19 +341,36 @@ describe('defaultActions', () => {
     });
     it('.fetch() with an empty body', () => {
       const actionId = 'delete';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/DELETE';
-      const context = {id: 1};
+      const context = {
+        id: 1
+      };
       const body = '';
       const code = 200;
       const options = {};
       nock(host)
         .delete(`/users/${context.id}`)
         .reply(code);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(res => {
         res.receivedAt = null;
@@ -222,19 +382,36 @@ describe('defaultActions', () => {
     });
     it('.fetch() with an non-json body', () => {
       const actionId = 'delete';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/DELETE';
-      const context = {id: 1};
+      const context = {
+        id: 1
+      };
       const body = 'foobar';
       const code = 200;
       const options = {};
       nock(host)
         .delete(`/users/${context.id}`)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(res => {
         res.receivedAt = null;
@@ -249,10 +426,15 @@ describe('defaultActions', () => {
   describe('errorHandling', () => {
     it('.fetch() with request errors', () => {
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       const err = {
         code: undefined,
         errno: undefined,
@@ -263,10 +445,22 @@ describe('defaultActions', () => {
       nock(host)
         .get('/users')
         .replyWithError('something awful happened');
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'rejected', type, context, options, err, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'rejected',
+          type,
+          context,
+          options,
+          err,
+          receivedAt: null
+        }
       ];
       return expect(store.dispatch(actionFuncs[action](context)))
         .rejects.toBeDefined()
@@ -281,19 +475,37 @@ describe('defaultActions', () => {
     });
     it('.fetch() with JSON response errors', () => {
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = {err: 'something awful happened'};
+      const body = {
+        err: 'something awful happened'
+      };
       const code = 400;
       const options = {};
       nock(host)
         .get('/users')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'rejected', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'rejected',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return expect(store.dispatch(actionFuncs[action](context)))
         .rejects.toBeDefined()
@@ -306,7 +518,10 @@ describe('defaultActions', () => {
     });
     it('.fetch() with HTML response errors', () => {
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
       const body = '<html><body><h1>something awful happened</h1></body></html>';
@@ -315,10 +530,23 @@ describe('defaultActions', () => {
       nock(host)
         .get('/users')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'rejected', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'rejected',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return expect(store.dispatch(actionFuncs[action](context)))
         .rejects.toBeDefined()
@@ -336,23 +564,55 @@ describe('custom actions', () => {
   afterEach(() => {
     nock.cleanAll();
   });
-  const customActions = {promote: {method: 'POST', url: `${url}/promote`}, merge: {method: 'POST', isArray: true}};
-  const actionFuncs = createActions(customActions, {resourceName, url});
+  const customActions = {
+    promote: {
+      method: 'POST',
+      url: `${url}/promote`
+    },
+    merge: {
+      method: 'POST',
+      isArray: true
+    }
+  };
+  const actionFuncs = createActions(customActions, {
+    resourceName,
+    url
+  });
   it('.promote()', () => {
     const actionId = 'promote';
-    const action = getActionName(actionId, {resourceName});
+    const action = getActionName(actionId, {
+      resourceName
+    });
     const type = '@@resource/USER/PROMOTE';
-    const context = {id: 1, firstName: 'Olivier'};
-    const body = {ok: true};
+    const context = {
+      id: 1,
+      firstName: 'Olivier'
+    };
+    const body = {
+      ok: true
+    };
     const code = 200;
     const options = {};
     nock(host)
       .post(`/users/${context.id}/promote`, context)
       .reply(code, body);
-    const store = mockStore({users: {}});
-    const expectedActions = [
-      {status: 'pending', type, context},
-      {status: 'resolved', type, context, options, body, code, receivedAt: null}
+    const store = mockStore({
+      users: {}
+    });
+    const expectedActions = [{
+        status: 'pending',
+        type,
+        context
+      },
+      {
+        status: 'resolved',
+        type,
+        context,
+        options,
+        body,
+        code,
+        receivedAt: null
+      }
     ];
     return store.dispatch(actionFuncs[action](context)).then(() => {
       const actions = store.getActions();
@@ -362,19 +622,40 @@ describe('custom actions', () => {
   });
   it('.merge()', () => {
     const actionId = 'merge';
-    const action = getActionName(actionId, {resourceName, isArray: true});
+    const action = getActionName(actionId, {
+      resourceName,
+      isArray: true
+    });
     const type = '@@resource/USER/MERGE';
     const context = {};
-    const body = [{id: 1, firstName: 'Olivier'}];
+    const body = [{
+      id: 1,
+      firstName: 'Olivier'
+    }];
     const code = 200;
-    const options = {isArray: true};
+    const options = {
+      isArray: true
+    };
     nock(host)
       .post('/users')
       .reply(code, body);
-    const store = mockStore({users: {}});
-    const expectedActions = [
-      {status: 'pending', type, context},
-      {status: 'resolved', type, context, options, body, code, receivedAt: null}
+    const store = mockStore({
+      users: {}
+    });
+    const expectedActions = [{
+        status: 'pending',
+        type,
+        context
+      },
+      {
+        status: 'resolved',
+        type,
+        context,
+        options,
+        body,
+        code,
+        receivedAt: null
+      }
     ];
     return store.dispatch(actionFuncs[action](context)).then(res => {
       const actions = store.getActions();
@@ -392,18 +673,37 @@ describe('custom pure actions', () => {
   const customActions = {
     clear: {
       isPure: true,
-      reduce: (state, action) => ({...state, item: null})
+      reduce: (state, action) => ({ ...state,
+        item: null
+      })
     }
   };
-  const actionFuncs = createActions(customActions, {resourceName, url});
+  const actionFuncs = createActions(customActions, {
+    resourceName,
+    url
+  });
   it('.clear()', () => {
     const actionId = 'clear';
-    const action = getActionName(actionId, {resourceName});
+    const action = getActionName(actionId, {
+      resourceName
+    });
     const type = '@@resource/USER/CLEAR';
-    const context = {id: 1, firstName: 'Olivier'};
-    const store = mockStore({users: {}});
-    const options = {isPure: true};
-    const expectedActions = [{status: 'resolved', type, context, options}];
+    const context = {
+      id: 1,
+      firstName: 'Olivier'
+    };
+    const store = mockStore({
+      users: {}
+    });
+    const options = {
+      isPure: true
+    };
+    const expectedActions = [{
+      status: 'resolved',
+      type,
+      context,
+      options
+    }];
     return store.dispatch(actionFuncs[action](context)).then(() => {
       const actions = store.getActions();
       expect(actions).toEqual(expectedActions);
@@ -415,37 +715,62 @@ describe('fetch options', () => {
   afterEach(() => {
     nock.cleanAll();
   });
-  const checkActionMethodSignature = (getState, {actionId} = {}) => {
+  const checkActionMethodSignature = (getState, {
+    actionId
+  } = {}) => {
     expect(typeof getState).toBe('function');
     expect(typeof actionId).toBe('string');
     expect(typeof getState()).toBe('object');
   };
   describe('`transformResponse` option', () => {
     it('should support action options', () => {
-      const transformResponse = res => ({...res, body: res.body.map(item => ({...item, foo: 'bar'}))});
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, transformResponse}},
-        {resourceName, url}
-      );
+      const transformResponse = res => ({ ...res,
+        body: res.body.map(item => ({ ...item,
+          foo: 'bar'
+        }))
+      });
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          transformResponse
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
         {
           status: 'resolved',
           type,
           context,
           options,
-          body: body.map(item => ({...item, foo: 'bar'})),
+          body: body.map(item => ({ ...item,
+            foo: 'bar'
+          })),
           code,
           receivedAt: null
         }
@@ -460,24 +785,49 @@ describe('fetch options', () => {
   describe('`url` option', () => {
     it('should support action override', () => {
       const overridenUrl = `${host}/teams/:id`;
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, url: overridenUrl}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          url: overridenUrl
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/teams')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -490,24 +840,49 @@ describe('fetch options', () => {
         checkActionMethodSignature(...args);
         return `${host}/teams/:id`;
       };
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, url: overridenUrl}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          url: overridenUrl
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/teams')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -517,23 +892,49 @@ describe('fetch options', () => {
     });
     it('should support context override', () => {
       const overridenUrl = `${host}/teams/:id`;
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/teams')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {url: overridenUrl})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        url: overridenUrl
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);
@@ -541,24 +942,48 @@ describe('fetch options', () => {
     });
     it('should support relative urls', () => {
       const overridenUrl = './merge';
-      const actionFuncs = createActions(
-        {...defaultActions, update: {...defaultActions.update, url: overridenUrl}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        update: { ...defaultActions.update,
+          url: overridenUrl
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'update';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/UPDATE';
-      const context = {id: 1, firstName: 'Olivier'};
-      const body = {ok: 1};
+      const context = {
+        id: 1,
+        firstName: 'Olivier'
+      };
+      const body = {
+        ok: 1
+      };
       const code = 200;
       const options = {};
       nock(host)
         .patch(`/users/${context.id}/merge`, context)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -570,24 +995,49 @@ describe('fetch options', () => {
   describe('`method` option', () => {
     it('should support action override', () => {
       const method = 'PATCH';
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, method}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          method
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .patch('/users')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -600,24 +1050,49 @@ describe('fetch options', () => {
         checkActionMethodSignature(...args);
         return 'PATCH';
       };
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, method}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          method
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .patch('/users')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -627,23 +1102,49 @@ describe('fetch options', () => {
     });
     it('should support context override', () => {
       const method = 'PATCH';
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .patch('/users')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {method})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        method
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);
@@ -652,25 +1153,52 @@ describe('fetch options', () => {
   });
   describe('`query` option', () => {
     it('should support action override', () => {
-      const query = {foo: 'bar'};
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, query}},
-        {resourceName, url}
-      );
+      const query = {
+        foo: 'bar'
+      };
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          query
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users?foo=bar')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -681,26 +1209,53 @@ describe('fetch options', () => {
     it('should support action override via function', () => {
       const query = (...args) => {
         checkActionMethodSignature(...args);
-        return {foo: 'bar'};
+        return {
+          foo: 'bar'
+        };
       };
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, query}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          query
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users?foo=bar')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -709,24 +1264,52 @@ describe('fetch options', () => {
       });
     });
     it('should support context override', () => {
-      const query = {foo: 'bar'};
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const query = {
+        foo: 'bar'
+      };
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users?foo=bar')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {query})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        query
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);
@@ -735,27 +1318,57 @@ describe('fetch options', () => {
     it('should support non-string query params', () => {
       const query = {
         select: ['firstName', 'lastName'],
-        populate: [{path: 'team', model: 'Team', select: ['id', 'name']}]
+        populate: [{
+          path: 'team',
+          model: 'Team',
+          select: ['id', 'name']
+        }]
       };
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get(
           '/users?select=[%22firstName%22,%22lastName%22]&populate=[%7B%22path%22:%22team%22,%22model%22:%22Team%22,%22select%22:[%22id%22,%22name%22]%7D]'
         )
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {query})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        query
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);
@@ -763,24 +1376,50 @@ describe('fetch options', () => {
     });
   });
   describe('`headers` option', () => {
-    Object.assign(defaultHeaders, {'X-Custom-Default-Header': 'foobar'});
+    Object.assign(defaultHeaders, {
+      'X-Custom-Default-Header': 'foobar'
+    });
     it('should support defaults override', () => {
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         .matchHeader('X-Custom-Default-Header', 'foobar')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -789,26 +1428,53 @@ describe('fetch options', () => {
       });
     });
     it('should support action override', () => {
-      const headers = {'X-Custom-Header': 'foobar'};
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, headers}},
-        {resourceName, url}
-      );
+      const headers = {
+        'X-Custom-Header': 'foobar'
+      };
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          headers
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         .matchHeader('X-Custom-Header', 'foobar')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -819,27 +1485,54 @@ describe('fetch options', () => {
     it('should support action override via function', () => {
       const headers = (...args) => {
         checkActionMethodSignature(...args);
-        return {'X-Custom-Header': 'foobar'};
+        return {
+          'X-Custom-Header': 'foobar'
+        };
       };
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, headers}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          headers
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         .matchHeader('X-Custom-Header', 'foobar')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -848,25 +1541,53 @@ describe('fetch options', () => {
       });
     });
     it('should support context override', () => {
-      const headers = {'X-Custom-Header': 'foobar'};
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const headers = {
+        'X-Custom-Header': 'foobar'
+      };
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         .matchHeader('X-Custom-Header', 'foobar')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {headers})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        headers
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);
@@ -876,26 +1597,51 @@ describe('fetch options', () => {
   describe('`credentials` option', () => {
     it('should support action override', () => {
       const credentials = 'include';
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, credentials}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          credentials
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         // .matchHeader('Access-Control-Allow-Origin', '*')
         // .matchHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -908,26 +1654,51 @@ describe('fetch options', () => {
         checkActionMethodSignature(...args);
         return 'include';
       };
-      const actionFuncs = createActions(
-        {...defaultActions, fetch: {...defaultActions.fetch, credentials}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        fetch: { ...defaultActions.fetch,
+          credentials
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         // .matchHeader('Access-Control-Allow-Origin', '*')
         // .matchHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -937,25 +1708,51 @@ describe('fetch options', () => {
     });
     it('should support context override', () => {
       const credentials = 'include';
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'fetch';
-      const action = getActionName(actionId, {resourceName, isArray: true});
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{id: 1, firstName: 'Olivier'}];
+      const body = [{
+        id: 1,
+        firstName: 'Olivier'
+      }];
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .get('/users')
         // .matchHeader('Access-Control-Allow-Origin', '*')
         // .matchHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {credentials})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        credentials
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);
@@ -964,24 +1761,50 @@ describe('fetch options', () => {
   });
   describe('`body` option', () => {
     it('should support context override', () => {
-      const contextBody = {firstName: 'Olivier'};
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const contextBody = {
+        firstName: 'Olivier'
+      };
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'update';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/UPDATE';
-      const context = {id: 1};
-      const body = {ok: true};
+      const context = {
+        id: 1
+      };
+      const body = {
+        ok: true
+      };
       const code = 200;
       const options = {};
       nock(host)
         .patch(`/users/${context.id}`, contextBody)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {body: contextBody})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        body: contextBody
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);
@@ -997,24 +1820,50 @@ describe('reduce options', () => {
   describe('`isArray` option', () => {
     it('should support action override', () => {
       const isArray = true;
-      const actionFuncs = createActions(
-        {...defaultActions, update: {...defaultActions.update, isArray}},
-        {resourceName, url}
-      );
-      const actionId = 'update';
-      const action = getActionName(actionId, {resourceName, isArray: true});
-      const type = '@@resource/USER/UPDATE';
-      const context = {id: 1, firstName: 'Olivier'};
-      const body = {ok: 1};
+      const actionFuncs = createActions({ ...defaultActions,
+        create: { ...defaultActions.create,
+          isArray
+        }
+      }, {
+        resourceName,
+        url
+      });
+      const actionId = 'create';
+      const action = getActionName(actionId, {
+        resourceName,
+        isArray: true
+      });
+      const type = '@@resource/USER/CREATE';
+      const context = {
+        firstName: 'Olivier'
+      };
+      const body = {
+        ok: 1
+      };
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
-        .patch(`/users/${context.id}`, context)
+        .post('/users', context)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -1024,23 +1873,50 @@ describe('reduce options', () => {
     });
     it('should support context override', () => {
       const isArray = true;
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'update';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/UPDATE';
-      const context = {id: 1, firstName: 'Olivier'};
-      const body = {ok: 1};
+      const context = {
+        id: 1,
+        firstName: 'Olivier'
+      };
+      const body = {
+        ok: 1
+      };
       const code = 200;
-      const options = {isArray: true};
+      const options = {
+        isArray: true
+      };
       nock(host)
         .patch(`/users/${context.id}`, context)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {isArray})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        isArray
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);
@@ -1050,24 +1926,50 @@ describe('reduce options', () => {
   describe('`assignResponse` option', () => {
     it('should support action override', () => {
       const assignResponse = true;
-      const actionFuncs = createActions(
-        {...defaultActions, update: {...defaultActions.update, assignResponse}},
-        {resourceName, url}
-      );
+      const actionFuncs = createActions({ ...defaultActions,
+        update: { ...defaultActions.update,
+          assignResponse
+        }
+      }, {
+        resourceName,
+        url
+      });
       const actionId = 'update';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/UPDATE';
-      const context = {id: 1, firstName: 'Olivier'};
-      const body = {ok: 1};
+      const context = {
+        id: 1,
+        firstName: 'Olivier'
+      };
+      const body = {
+        ok: 1
+      };
       const code = 200;
-      const options = {assignResponse: true};
+      const options = {
+        assignResponse: true
+      };
       nock(host)
         .patch(`/users/${context.id}`, context)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
       return store.dispatch(actionFuncs[action](context)).then(() => {
         const actions = store.getActions();
@@ -1077,23 +1979,50 @@ describe('reduce options', () => {
     });
     it('should support context override', () => {
       const assignResponse = true;
-      const actionFuncs = createActions(defaultActions, {resourceName, url});
+      const actionFuncs = createActions(defaultActions, {
+        resourceName,
+        url
+      });
       const actionId = 'update';
-      const action = getActionName(actionId, {resourceName});
+      const action = getActionName(actionId, {
+        resourceName
+      });
       const type = '@@resource/USER/UPDATE';
-      const context = {id: 1, firstName: 'Olivier'};
-      const body = {ok: 1};
+      const context = {
+        id: 1,
+        firstName: 'Olivier'
+      };
+      const body = {
+        ok: 1
+      };
       const code = 200;
-      const options = {assignResponse: true};
+      const options = {
+        assignResponse: true
+      };
       nock(host)
         .patch(`/users/${context.id}`, context)
         .reply(code, body);
-      const store = mockStore({users: {}});
-      const expectedActions = [
-        {status: 'pending', type, context},
-        {status: 'resolved', type, context, options, body, code, receivedAt: null}
+      const store = mockStore({
+        users: {}
+      });
+      const expectedActions = [{
+          status: 'pending',
+          type,
+          context
+        },
+        {
+          status: 'resolved',
+          type,
+          context,
+          options,
+          body,
+          code,
+          receivedAt: null
+        }
       ];
-      return store.dispatch(actionFuncs[action](context, {assignResponse})).then(() => {
+      return store.dispatch(actionFuncs[action](context, {
+        assignResponse
+      })).then(() => {
         const actions = store.getActions();
         actions[1].receivedAt = null;
         expect(actions).toEqual(expectedActions);

--- a/test/spec/actions.spec.js
+++ b/test/spec/actions.spec.js
@@ -1,19 +1,11 @@
-import {
-  values
-} from 'lodash';
+import {values} from 'lodash';
 import configureMockStore from 'redux-mock-store';
 import expect from 'expect';
 import nock from 'nock';
 import thunk from 'redux-thunk';
 
-import {
-  defaultActions,
-  defaultHeaders
-} from '../../src';
-import {
-  createActions,
-  getActionName
-} from '../../src/actions';
+import {defaultActions, defaultHeaders} from '../../src';
+import {createActions, getActionName} from '../../src/actions';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -30,7 +22,15 @@ describe('createActions', () => {
         resourceName,
         url
       });
-      const expectedKeys = ['createUser', 'fetchUsers', 'getUser', 'updateUser', 'updateUsers', 'deleteUser'];
+      const expectedKeys = [
+        'createUser',
+        'fetchUsers',
+        'getUser',
+        'updateUser',
+        'updateUsers',
+        'deleteUser',
+        'deleteUsers'
+      ];
       expect(Object.keys(actionFuncs)).toEqual(expectedKeys);
     });
     it('should return an object with properly typed values', () => {
@@ -47,7 +47,7 @@ describe('createActions', () => {
       const actionFuncs = createActions(defaultActions, {
         url
       });
-      const expectedKeys = ['create', 'fetch', 'get', 'update', 'updateArray', 'delete'];
+      const expectedKeys = ['create', 'fetch', 'get', 'update', 'updateArray', 'delete', 'deleteArray'];
       expect(Object.keys(actionFuncs)).toEqual(expectedKeys);
     });
     it('should return an object with properly typed values', () => {
@@ -91,7 +91,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -122,10 +123,12 @@ describe('defaultActions', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -136,7 +139,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -180,7 +184,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -224,7 +229,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -267,7 +273,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -316,7 +323,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -357,7 +365,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -398,7 +407,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -448,7 +458,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -492,7 +503,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -533,7 +545,8 @@ describe('defaultActions', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -599,7 +612,8 @@ describe('custom actions', () => {
     const store = mockStore({
       users: {}
     });
-    const expectedActions = [{
+    const expectedActions = [
+      {
         status: 'pending',
         type,
         context
@@ -628,10 +642,12 @@ describe('custom actions', () => {
     });
     const type = '@@resource/USER/MERGE';
     const context = {};
-    const body = [{
-      id: 1,
-      firstName: 'Olivier'
-    }];
+    const body = [
+      {
+        id: 1,
+        firstName: 'Olivier'
+      }
+    ];
     const code = 200;
     const options = {
       isArray: true
@@ -642,7 +658,8 @@ describe('custom actions', () => {
     const store = mockStore({
       users: {}
     });
-    const expectedActions = [{
+    const expectedActions = [
+      {
         status: 'pending',
         type,
         context
@@ -673,7 +690,8 @@ describe('custom pure actions', () => {
   const customActions = {
     clear: {
       isPure: true,
-      reduce: (state, action) => ({ ...state,
+      reduce: (state, action) => ({
+        ...state,
         item: null
       })
     }
@@ -698,12 +716,14 @@ describe('custom pure actions', () => {
     const options = {
       isPure: true
     };
-    const expectedActions = [{
-      status: 'resolved',
-      type,
-      context,
-      options
-    }];
+    const expectedActions = [
+      {
+        status: 'resolved',
+        type,
+        context,
+        options
+      }
+    ];
     return store.dispatch(actionFuncs[action](context)).then(() => {
       const actions = store.getActions();
       expect(actions).toEqual(expectedActions);
@@ -715,28 +735,33 @@ describe('fetch options', () => {
   afterEach(() => {
     nock.cleanAll();
   });
-  const checkActionMethodSignature = (getState, {
-    actionId
-  } = {}) => {
+  const checkActionMethodSignature = (getState, {actionId} = {}) => {
     expect(typeof getState).toBe('function');
     expect(typeof actionId).toBe('string');
     expect(typeof getState()).toBe('object');
   };
   describe('`transformResponse` option', () => {
     it('should support action options', () => {
-      const transformResponse = res => ({ ...res,
-        body: res.body.map(item => ({ ...item,
+      const transformResponse = res => ({
+        ...res,
+        body: res.body.map(item => ({
+          ...item,
           foo: 'bar'
         }))
       });
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          transformResponse
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            transformResponse
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -744,10 +769,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -758,7 +785,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -768,7 +796,8 @@ describe('fetch options', () => {
           type,
           context,
           options,
-          body: body.map(item => ({ ...item,
+          body: body.map(item => ({
+            ...item,
             foo: 'bar'
           })),
           code,
@@ -785,14 +814,19 @@ describe('fetch options', () => {
   describe('`url` option', () => {
     it('should support action override', () => {
       const overridenUrl = `${host}/teams/:id`;
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          url: overridenUrl
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            url: overridenUrl
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -800,10 +834,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -814,7 +850,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -840,14 +877,19 @@ describe('fetch options', () => {
         checkActionMethodSignature(...args);
         return `${host}/teams/:id`;
       };
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          url: overridenUrl
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            url: overridenUrl
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -855,10 +897,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -869,7 +913,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -903,10 +948,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -917,7 +964,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -932,24 +980,33 @@ describe('fetch options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        url: overridenUrl
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            url: overridenUrl
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
     it('should support relative urls', () => {
       const overridenUrl = './merge';
-      const actionFuncs = createActions({ ...defaultActions,
-        update: { ...defaultActions.update,
-          url: overridenUrl
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          update: {
+            ...defaultActions.update,
+            url: overridenUrl
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'update';
       const action = getActionName(actionId, {
         resourceName
@@ -970,7 +1027,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -995,14 +1053,19 @@ describe('fetch options', () => {
   describe('`method` option', () => {
     it('should support action override', () => {
       const method = 'PATCH';
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          method
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            method
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -1010,10 +1073,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1024,7 +1089,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1050,14 +1116,19 @@ describe('fetch options', () => {
         checkActionMethodSignature(...args);
         return 'PATCH';
       };
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          method
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            method
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -1065,10 +1136,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1079,7 +1152,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1113,10 +1187,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1127,7 +1203,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1142,13 +1219,17 @@ describe('fetch options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        method
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            method
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
   });
   describe('`query` option', () => {
@@ -1156,14 +1237,19 @@ describe('fetch options', () => {
       const query = {
         foo: 'bar'
       };
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          query
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            query
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -1171,10 +1257,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1185,7 +1273,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1213,14 +1302,19 @@ describe('fetch options', () => {
           foo: 'bar'
         };
       };
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          query
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            query
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -1228,10 +1322,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1242,7 +1338,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1278,10 +1375,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1292,7 +1391,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1307,22 +1407,28 @@ describe('fetch options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        query
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            query
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
     it('should support non-string query params', () => {
       const query = {
         select: ['firstName', 'lastName'],
-        populate: [{
-          path: 'team',
-          model: 'Team',
-          select: ['id', 'name']
-        }]
+        populate: [
+          {
+            path: 'team',
+            model: 'Team',
+            select: ['id', 'name']
+          }
+        ]
       };
       const actionFuncs = createActions(defaultActions, {
         resourceName,
@@ -1335,10 +1441,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1351,7 +1459,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1366,13 +1475,17 @@ describe('fetch options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        query
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            query
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
   });
   describe('`headers` option', () => {
@@ -1391,10 +1504,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1406,7 +1521,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1431,14 +1547,19 @@ describe('fetch options', () => {
       const headers = {
         'X-Custom-Header': 'foobar'
       };
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          headers
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            headers
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -1446,10 +1567,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1461,7 +1584,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1489,14 +1613,19 @@ describe('fetch options', () => {
           'X-Custom-Header': 'foobar'
         };
       };
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          headers
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            headers
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -1504,10 +1633,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1519,7 +1650,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1555,10 +1687,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1570,7 +1704,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1585,26 +1720,35 @@ describe('fetch options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        headers
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            headers
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
   });
   describe('`credentials` option', () => {
     it('should support action override', () => {
       const credentials = 'include';
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          credentials
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            credentials
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -1612,10 +1756,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1628,7 +1774,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1654,14 +1801,19 @@ describe('fetch options', () => {
         checkActionMethodSignature(...args);
         return 'include';
       };
-      const actionFuncs = createActions({ ...defaultActions,
-        fetch: { ...defaultActions.fetch,
-          credentials
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          fetch: {
+            ...defaultActions.fetch,
+            credentials
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'fetch';
       const action = getActionName(actionId, {
         resourceName,
@@ -1669,10 +1821,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1685,7 +1839,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1719,10 +1874,12 @@ describe('fetch options', () => {
       });
       const type = '@@resource/USER/FETCH';
       const context = {};
-      const body = [{
-        id: 1,
-        firstName: 'Olivier'
-      }];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        }
+      ];
       const code = 200;
       const options = {
         isArray: true
@@ -1735,7 +1892,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1750,13 +1908,17 @@ describe('fetch options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        credentials
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            credentials
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
   });
   describe('`body` option', () => {
@@ -1787,7 +1949,8 @@ describe('fetch options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1802,13 +1965,17 @@ describe('fetch options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        body: contextBody
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            body: contextBody
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
   });
 });
@@ -1820,14 +1987,19 @@ describe('reduce options', () => {
   describe('`isArray` option', () => {
     it('should support action override', () => {
       const isArray = true;
-      const actionFuncs = createActions({ ...defaultActions,
-        create: { ...defaultActions.create,
-          isArray
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          create: {
+            ...defaultActions.create,
+            isArray
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'create';
       const action = getActionName(actionId, {
         resourceName,
@@ -1850,7 +2022,8 @@ describe('reduce options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1899,7 +2072,8 @@ describe('reduce options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -1914,26 +2088,35 @@ describe('reduce options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        isArray
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            isArray
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
   });
   describe('`assignResponse` option', () => {
     it('should support action override', () => {
       const assignResponse = true;
-      const actionFuncs = createActions({ ...defaultActions,
-        update: { ...defaultActions.update,
-          assignResponse
+      const actionFuncs = createActions(
+        {
+          ...defaultActions,
+          update: {
+            ...defaultActions.update,
+            assignResponse
+          }
+        },
+        {
+          resourceName,
+          url
         }
-      }, {
-        resourceName,
-        url
-      });
+      );
       const actionId = 'update';
       const action = getActionName(actionId, {
         resourceName
@@ -1956,7 +2139,8 @@ describe('reduce options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -2005,7 +2189,8 @@ describe('reduce options', () => {
       const store = mockStore({
         users: {}
       });
-      const expectedActions = [{
+      const expectedActions = [
+        {
           status: 'pending',
           type,
           context
@@ -2020,13 +2205,17 @@ describe('reduce options', () => {
           receivedAt: null
         }
       ];
-      return store.dispatch(actionFuncs[action](context, {
-        assignResponse
-      })).then(() => {
-        const actions = store.getActions();
-        actions[1].receivedAt = null;
-        expect(actions).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(
+          actionFuncs[action](context, {
+            assignResponse
+          })
+        )
+        .then(() => {
+          const actions = store.getActions();
+          actions[1].receivedAt = null;
+          expect(actions).toEqual(expectedActions);
+        });
     });
   });
 });

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -27,9 +27,9 @@ describe('createResource', () => {
       actions: {get: {foo: 'bar'}, charge: {method: 'post'}}
     });
     expect(typeof types).toBe('object');
-    expect(Object.keys(types).length).toEqual(7);
+    expect(Object.keys(types).length).toEqual(8);
     expect(typeof actions).toBe('object');
-    expect(Object.keys(actions).length).toEqual(7);
+    expect(Object.keys(actions).length).toEqual(8);
     expect(typeof reducers).toBe('function');
     expect(typeof rootReducer).toBe('function');
   });

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -27,9 +27,9 @@ describe('createResource', () => {
       actions: {get: {foo: 'bar'}, charge: {method: 'post'}}
     });
     expect(typeof types).toBe('object');
-    expect(Object.keys(types).length).toEqual(6);
+    expect(Object.keys(types).length).toEqual(7);
     expect(typeof actions).toBe('object');
-    expect(Object.keys(actions).length).toEqual(6);
+    expect(Object.keys(actions).length).toEqual(7);
     expect(typeof reducers).toBe('function');
     expect(typeof rootReducer).toBe('function');
   });

--- a/test/spec/reducers.spec.js
+++ b/test/spec/reducers.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import {values} from 'lodash';
+import {values, snakeCase} from 'lodash';
 
 import {defaultActions, initialState} from '../../src/defaults';
 import {createTypes, getActionTypeKey} from '../../src/types';
@@ -12,61 +12,132 @@ const resourceName = 'user';
 
 describe('createReducers', () => {
   it('should return a reduce function', () => {
-    const reducers = createReducers(defaultActions, {resourceName});
+    const reducers = createReducers(defaultActions, {
+      resourceName
+    });
     expect(typeof reducers).toBe('object');
     const expectedValuesFn = reducer => expect(typeof reducer).toBe('function');
     values(reducers).forEach(expectedValuesFn);
   });
   it('should return a reduce function', () => {
-    const reducers = createReducers(defaultActions, {resourceName});
-    const rootReducer = createRootReducer(reducers, {resourceName});
+    const reducers = createReducers(defaultActions, {
+      resourceName
+    });
+    const rootReducer = createRootReducer(reducers, {
+      resourceName
+    });
     expect(typeof rootReducer).toBe('function');
   });
   it('should return the initial state', () => {
-    const reducers = createReducers(defaultActions, {resourceName});
-    const rootReducer = createRootReducer(reducers, {resourceName});
+    const reducers = createReducers(defaultActions, {
+      resourceName
+    });
+    const rootReducer = createRootReducer(reducers, {
+      resourceName
+    });
     expect(rootReducer(undefined, {})).toEqual(initialState);
   });
 });
 
 describe('defaultReducers', () => {
-  const types = createTypes(defaultActions, {resourceName});
-  const reducers = createReducers(defaultActions, {resourceName});
+  const types = createTypes(defaultActions, {
+    resourceName
+  });
+  const reducers = createReducers(defaultActions, {
+    resourceName
+  });
   it('should handle CREATE action', () => {
     const actionId = 'create';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
-    const context = {firstName: 'Olivier'};
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const context = {
+      firstName: 'Olivier'
+    };
     let status;
 
     status = 'pending';
-    const pendingAction = {type, status, context};
+    const pendingAction = {
+      type,
+      status,
+      context
+    };
     const pendingState = reducers[actionId](undefined, pendingAction);
-    expect(pendingState).toEqual({isCreating: true});
+    expect(pendingState).toEqual({
+      isCreating: true
+    });
 
     status = 'resolved';
-    const body = {id: 1, firstName: 'Olivier'};
+    const body = {
+      id: 1,
+      firstName: 'Olivier'
+    };
     const receivedAt = Date.now();
-    const resolvedAction = {type, status, context, body, receivedAt};
-    expect(reducers[actionId](pendingState, resolvedAction)).toEqual({isCreating: false, items: [body]});
+    const resolvedAction = {
+      type,
+      status,
+      context,
+      body,
+      receivedAt
+    };
+    expect(reducers[actionId](pendingState, resolvedAction)).toEqual({
+      isCreating: false,
+      items: [body]
+    });
 
     status = 'rejected';
-    const rejectedAction = {type, status, context, err: {}, receivedAt};
-    expect(reducers[actionId](pendingState, rejectedAction)).toEqual({isCreating: false});
+    const rejectedAction = {
+      type,
+      status,
+      context,
+      err: {},
+      receivedAt
+    };
+    expect(reducers[actionId](pendingState, rejectedAction)).toEqual({
+      isCreating: false
+    });
   });
   it('should handle FETCH action (classic fetch)', () => {
     const actionId = 'fetch';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
     let status;
 
     status = 'pending';
-    const pendingState = reducers[actionId](undefined, {type, status});
-    expect(pendingState).toEqual({isFetching: true, didInvalidate: false});
+    const pendingState = reducers[actionId](undefined, {
+      type,
+      status
+    });
+    expect(pendingState).toEqual({
+      isFetching: true,
+      didInvalidate: false
+    });
 
     status = 'resolved';
     const code = 200;
-    const body = [{id: 1, firstName: 'Olivier'}];
+    const body = [
+      {
+        id: 1,
+        firstName: 'Olivier'
+      }
+    ];
     const receivedAt = Date.now();
-    expect(reducers[actionId](pendingState, {type, status, body, receivedAt, code})).toEqual({
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        body,
+        receivedAt,
+        code
+      })
+    ).toEqual({
       isFetching: false,
       didInvalidate: false,
       items: body,
@@ -74,7 +145,14 @@ describe('defaultReducers', () => {
     });
 
     status = 'rejected';
-    expect(reducers[actionId](pendingState, {type, status, err: {}, receivedAt})).toEqual({
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
       didInvalidate: false,
       isFetching: false
     });
@@ -82,19 +160,52 @@ describe('defaultReducers', () => {
   describe('should handle FETCH action with Content-Range header', () => {
     it('partial-content fetch => first range [0 to 2]', () => {
       const actionId = 'fetch';
-      const type = types[getActionTypeKey(actionId, {resourceName})];
+      const type =
+        types[
+          getActionTypeKey(actionId, {
+            resourceName
+          })
+        ];
       let status;
 
       status = 'pending';
-      const pendingState = reducers[actionId](undefined, {type, status});
-      expect(pendingState).toEqual({isFetching: true, didInvalidate: false});
+      const pendingState = reducers[actionId](undefined, {
+        type,
+        status
+      });
+      expect(pendingState).toEqual({
+        isFetching: true,
+        didInvalidate: false
+      });
 
       status = 'resolved';
       const code = 206;
       const contentRange = parseContentRangeHeader('users 0-2/3');
-      const body = [{id: 1, firstName: 'Olivier'}, {id: 2, firstName: 'Romain'}, {id: 3, firstName: 'someone'}];
+      const body = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        },
+        {
+          id: 2,
+          firstName: 'Romain'
+        },
+        {
+          id: 3,
+          firstName: 'someone'
+        }
+      ];
       const receivedAt = Date.now();
-      expect(reducers[actionId](pendingState, {type, status, body, receivedAt, code, contentRange})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          body,
+          receivedAt,
+          code,
+          contentRange
+        })
+      ).toEqual({
         isFetching: false,
         didInvalidate: false,
         items: body,
@@ -102,27 +213,86 @@ describe('defaultReducers', () => {
       });
 
       status = 'rejected';
-      expect(reducers[actionId](pendingState, {type, status, err: {}, receivedAt})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          err: {},
+          receivedAt
+        })
+      ).toEqual({
         didInvalidate: false,
         isFetching: false
       });
     });
     it('partial-content fetch => first range [0 to 2] with 3 old items', () => {
       const actionId = 'fetch';
-      const type = types[getActionTypeKey(actionId, {resourceName})];
-      const oldItems = [{id: 1, firstName: 'Olivier'}, {id: 2, firstName: 'Romain'}, {id: 3, firstName: 'someone'}];
+      const type =
+        types[
+          getActionTypeKey(actionId, {
+            resourceName
+          })
+        ];
+      const oldItems = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        },
+        {
+          id: 2,
+          firstName: 'Romain'
+        },
+        {
+          id: 3,
+          firstName: 'someone'
+        }
+      ];
       let status;
 
       status = 'pending';
-      const pendingState = reducers[actionId]({items: oldItems}, {type, status});
-      expect(pendingState).toEqual({isFetching: true, didInvalidate: false, items: oldItems});
+      const pendingState = reducers[actionId](
+        {
+          items: oldItems
+        },
+        {
+          type,
+          status
+        }
+      );
+      expect(pendingState).toEqual({
+        isFetching: true,
+        didInvalidate: false,
+        items: oldItems
+      });
 
       status = 'resolved';
       const code = 206;
       const contentRange = parseContentRangeHeader('users 0-2/3');
-      const body = [{id: 11, firstName: 'Olivier'}, {id: 12, firstName: 'Romain'}, {id: 13, firstName: 'someone'}];
+      const body = [
+        {
+          id: 11,
+          firstName: 'Olivier'
+        },
+        {
+          id: 12,
+          firstName: 'Romain'
+        },
+        {
+          id: 13,
+          firstName: 'someone'
+        }
+      ];
       const receivedAt = Date.now();
-      expect(reducers[actionId](pendingState, {type, status, body, receivedAt, code, contentRange})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          body,
+          receivedAt,
+          code,
+          contentRange
+        })
+      ).toEqual({
         isFetching: false,
         didInvalidate: false,
         items: body,
@@ -130,7 +300,14 @@ describe('defaultReducers', () => {
       });
 
       status = 'rejected';
-      expect(reducers[actionId](pendingState, {type, status, err: {}, receivedAt})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          err: {},
+          receivedAt
+        })
+      ).toEqual({
         didInvalidate: false,
         isFetching: false,
         items: oldItems
@@ -138,20 +315,68 @@ describe('defaultReducers', () => {
     });
     it('partial-content fetch => next range [3 to 4] with 3 old items', () => {
       const actionId = 'fetch';
-      const type = types[getActionTypeKey(actionId, {resourceName})];
-      const oldItems = [{id: 1, firstName: 'Olivier'}, {id: 2, firstName: 'Romain'}, {id: 3, firstName: 'someone'}];
+      const type =
+        types[
+          getActionTypeKey(actionId, {
+            resourceName
+          })
+        ];
+      const oldItems = [
+        {
+          id: 1,
+          firstName: 'Olivier'
+        },
+        {
+          id: 2,
+          firstName: 'Romain'
+        },
+        {
+          id: 3,
+          firstName: 'someone'
+        }
+      ];
       let status;
 
       status = 'pending';
-      const pendingState = reducers[actionId]({items: oldItems}, {type, status});
-      expect(pendingState).toEqual({isFetching: true, didInvalidate: false, items: oldItems});
+      const pendingState = reducers[actionId](
+        {
+          items: oldItems
+        },
+        {
+          type,
+          status
+        }
+      );
+      expect(pendingState).toEqual({
+        isFetching: true,
+        didInvalidate: false,
+        items: oldItems
+      });
 
       status = 'resolved';
       const code = 206;
       const contentRange = parseContentRangeHeader('users 3-4/2');
-      const body = [{id: 4, firstName: 'somebody'}, {id: 5, firstName: 'someone else'}];
+      const body = [
+        {
+          id: 4,
+          firstName: 'somebody'
+        },
+        {
+          id: 5,
+          firstName: 'someone else'
+        }
+      ];
       const receivedAt = Date.now();
-      expect(reducers[actionId](pendingState, {type, status, body, receivedAt, code, contentRange})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          body,
+          receivedAt,
+          code,
+          contentRange
+        })
+      ).toEqual({
         isFetching: false,
         didInvalidate: false,
         items: oldItems.concat(body),
@@ -159,7 +384,14 @@ describe('defaultReducers', () => {
       });
 
       status = 'rejected';
-      expect(reducers[actionId](pendingState, {type, status, err: {}, receivedAt})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          err: {},
+          receivedAt
+        })
+      ).toEqual({
         didInvalidate: false,
         isFetching: false,
         items: oldItems
@@ -168,18 +400,45 @@ describe('defaultReducers', () => {
   });
   it('should handle GET action', () => {
     const actionId = 'get';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
-    const context = {id: 1};
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const context = {
+      id: 1
+    };
     let status;
 
     status = 'pending';
-    const pendingState = reducers[actionId](undefined, {type, status, context});
-    expect(pendingState).toEqual({isFetchingItem: true, didInvalidateItem: false});
+    const pendingState = reducers[actionId](undefined, {
+      type,
+      status,
+      context
+    });
+    expect(pendingState).toEqual({
+      isFetchingItem: true,
+      didInvalidateItem: false
+    });
 
     status = 'resolved';
-    const body = [{id: 1, firstName: 'Olivier'}];
+    const body = [
+      {
+        id: 1,
+        firstName: 'Olivier'
+      }
+    ];
     const receivedAt = Date.now();
-    expect(reducers[actionId](pendingState, {type, status, context, body, receivedAt})).toEqual({
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        body,
+        receivedAt
+      })
+    ).toEqual({
       isFetchingItem: false,
       didInvalidateItem: false,
       item: body,
@@ -187,63 +446,420 @@ describe('defaultReducers', () => {
     });
 
     status = 'rejected';
-    expect(reducers[actionId](pendingState, {type, status, context, err: {}, receivedAt})).toEqual({
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
       isFetchingItem: false,
       didInvalidateItem: false
     });
   });
   it('should handle UPDATE action', () => {
     const actionId = 'update';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
-    const initialItems = [{id: 1, firstName: 'Olivier', lastName: 'Louvignes'}];
-    const customInitialState = {items: initialItems, item: initialItems[0]};
-    const context = {id: 1, firstName: 'Olivia'};
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const initialItems = [
+      {
+        id: 1,
+        firstName: 'Olivier',
+        lastName: 'Louvignes'
+      }
+    ];
+    const customInitialState = {
+      items: initialItems,
+      item: initialItems[0]
+    };
+    const context = {
+      id: 1,
+      firstName: 'Olivia'
+    };
     let status;
 
     status = 'pending';
-    const pendingState = reducers[actionId](customInitialState, {type, status, context});
-    expect(pendingState).toEqual({...customInitialState, isUpdating: true});
+    const pendingState = reducers[actionId](customInitialState, {
+      type,
+      status,
+      context
+    });
+    expect(pendingState).toEqual({
+      ...customInitialState,
+      isUpdating: true
+    });
 
     status = 'resolved';
-    const body = {ok: true};
+    const body = {
+      ok: true
+    };
     const receivedAt = Date.now();
-    const expectedItems = [{id: 1, firstName: 'Olivia', lastName: 'Louvignes'}];
+    const expectedItems = [
+      {
+        id: 1,
+        firstName: 'Olivia',
+        lastName: 'Louvignes'
+      }
+    ];
     const expectedItem = expectedItems[0];
-    expect(reducers[actionId](pendingState, {type, status, context, body, receivedAt})).toEqual({
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        body,
+        receivedAt
+      })
+    ).toEqual({
       isUpdating: false,
       items: expectedItems,
       item: expectedItem
     });
 
     status = 'rejected';
-    expect(reducers[actionId](pendingState, {type, status, context, err: {}, receivedAt})).toEqual({
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
       ...customInitialState,
       isUpdating: false
     });
   });
-  it('should handle DELETE action', () => {
-    const actionId = 'delete';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
-    const initialItems = [{id: 1, firstName: 'Olivier', lastName: 'Louvignes'}];
-    const customInitialState = {items: initialItems};
-    const context = {id: 1};
+
+  it('should handle UPDATE_ARRAY action with ids in context object', () => {
+    const actionId = snakeCase('updateArray');
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const initialItems = [
+      {
+        id: 1,
+        firstName: 'Olivier',
+        lastName: 'Louvignes'
+      },
+      {
+        id: 2,
+        firstName: 'Nathan',
+        lastName: 'Ducrey'
+      }
+    ];
+    const customInitialState = {
+      items: initialItems,
+      item: initialItems[0]
+    };
+    const context = {
+      ids: [1, 2],
+      firstName: 'Olivia'
+    };
     let status;
 
     status = 'pending';
-    const pendingState = reducers[actionId](customInitialState, {type, status, context});
-    expect(pendingState).toEqual({...customInitialState, isDeleting: true});
+    const pendingState = reducers[actionId](customInitialState, {
+      type,
+      status,
+      context
+    });
+    expect(pendingState).toEqual({
+      ...customInitialState,
+      isBatchUpdating: true
+    });
 
     status = 'resolved';
-    const body = {ok: true};
+    const body = {
+      ok: true
+    };
+    const receivedAt = Date.now();
+    const expectedItems = [
+      {
+        id: 1,
+        firstName: 'Olivia',
+        lastName: 'Louvignes'
+      },
+      {
+        id: 2,
+        firstName: 'Olivia',
+        lastName: 'Ducrey'
+      }
+    ];
+    const expectedItem = expectedItems[0];
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        body,
+        receivedAt
+      })
+    ).toEqual({
+      isBatchUpdating: false,
+      items: expectedItems,
+      item: expectedItem
+    });
+
+    status = 'rejected';
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
+      ...customInitialState,
+      isBatchUpdating: false
+    });
+  });
+  it('should handle UPDATE_ARRAY action with ids in query object', () => {
+    const actionId = snakeCase('updateArray');
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const initialItems = [
+      {
+        id: 1,
+        firstName: 'Olivier',
+        lastName: 'Louvignes'
+      },
+      {
+        id: 2,
+        firstName: 'Nathan',
+        lastName: 'Ducrey'
+      }
+    ];
+    const customInitialState = {
+      items: initialItems,
+      item: initialItems[0]
+    };
+    const context = {
+      firstName: 'Olivia'
+    };
+    let status;
+
+    status = 'pending';
+    const pendingState = reducers[actionId](customInitialState, {
+      type,
+      status,
+      context,
+      query: {ids: [1, 2]}
+    });
+    expect(pendingState).toEqual({
+      ...customInitialState,
+      isBatchUpdating: true
+    });
+
+    status = 'resolved';
+    const body = {
+      ok: true
+    };
+    const receivedAt = Date.now();
+    const expectedItems = [
+      {
+        id: 1,
+        firstName: 'Olivia',
+        lastName: 'Louvignes'
+      },
+      {
+        id: 2,
+        firstName: 'Olivia',
+        lastName: 'Ducrey'
+      }
+    ];
+    const expectedItem = expectedItems[0];
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        body,
+        receivedAt
+      })
+    ).toEqual({
+      isBatchUpdating: false,
+      items: expectedItems,
+      item: expectedItem
+    });
+
+    status = 'rejected';
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
+      ...customInitialState,
+      isBatchUpdating: false
+    });
+  });
+  it('should handle UPDATE_ARRAY action with assignResponse to true', () => {
+    const actionId = snakeCase('updateArray');
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const initialItems = [
+      {
+        id: 1,
+        firstName: 'Olivier',
+        lastName: 'Louvignes'
+      },
+      {
+        id: 2,
+        firstName: 'Nathan',
+        lastName: 'Ducrey'
+      }
+    ];
+    const customInitialState = {
+      items: initialItems,
+      item: initialItems[0]
+    };
+    const context = {
+      firstName: 'Olivia'
+    };
+    let status;
+
+    status = 'pending';
+    const pendingState = reducers[actionId](customInitialState, {
+      type,
+      status,
+      context,
+      query: {ids: [1, 2]},
+      assignResponse: true
+    });
+    expect(pendingState).toEqual({
+      ...customInitialState,
+      isBatchUpdating: true
+    });
+
+    status = 'resolved';
+    const body = [
+      {
+        id: 1,
+        firstName: 'Olivia',
+        lastName: 'Louvignes'
+      },
+      {
+        id: 2,
+        firstName: 'Olivia',
+        lastName: 'Ducrey'
+      }
+    ];
+    const receivedAt = Date.now();
+    const expectedItems = body;
+    const expectedItem = expectedItems[0];
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        body,
+        receivedAt
+      })
+    ).toEqual({
+      isBatchUpdating: false,
+      items: expectedItems,
+      item: expectedItem
+    });
+
+    status = 'rejected';
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
+      ...customInitialState,
+      isBatchUpdating: false
+    });
+  });
+  it('should handle DELETE action', () => {
+    const actionId = 'delete';
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const initialItems = [
+      {
+        id: 1,
+        firstName: 'Olivier',
+        lastName: 'Louvignes'
+      }
+    ];
+    const customInitialState = {
+      items: initialItems
+    };
+    const context = {
+      id: 1
+    };
+    let status;
+
+    status = 'pending';
+    const pendingState = reducers[actionId](customInitialState, {
+      type,
+      status,
+      context
+    });
+    expect(pendingState).toEqual({
+      ...customInitialState,
+      isDeleting: true
+    });
+
+    status = 'resolved';
+    const body = {
+      ok: true
+    };
     const receivedAt = Date.now();
     const expectedItems = [];
-    expect(reducers[actionId](pendingState, {type, status, context, body, receivedAt})).toEqual({
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        body,
+        receivedAt
+      })
+    ).toEqual({
       isDeleting: false,
       items: expectedItems
     });
 
     status = 'rejected';
-    expect(reducers[actionId](pendingState, {type, status, context, err: {}, receivedAt})).toEqual({
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
       ...customInitialState,
       isDeleting: false
     });
@@ -251,46 +867,123 @@ describe('defaultReducers', () => {
 });
 
 describe('custom reducers', () => {
-  const customActions = {run: {method: 'POST', gerundName: 'running'}, merge: {method: 'POST', isArray: true}};
-  const types = createTypes(customActions, {resourceName});
-  const reducers = createReducers(customActions, {resourceName});
+  const customActions = {
+    run: {
+      method: 'POST',
+      gerundName: 'running'
+    },
+    merge: {
+      method: 'POST',
+      isArray: true
+    }
+  };
+  const types = createTypes(customActions, {
+    resourceName
+  });
+  const reducers = createReducers(customActions, {
+    resourceName
+  });
   it('should handle RUN action', () => {
     const actionId = 'run';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
-    const context = {firstName: 'Olivier'};
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const context = {
+      firstName: 'Olivier'
+    };
     let status;
 
     status = 'pending';
-    const pendingAction = {type, status, context};
+    const pendingAction = {
+      type,
+      status,
+      context
+    };
     const pendingState = reducers[actionId](undefined, pendingAction);
-    expect(pendingState).toEqual({isRunning: true});
+    expect(pendingState).toEqual({
+      isRunning: true
+    });
 
     status = 'resolved';
-    const body = {ok: 1};
+    const body = {
+      ok: 1
+    };
     const receivedAt = Date.now();
-    const resolvedAction = {type, status, context, body, receivedAt};
-    expect(reducers[actionId](pendingState, resolvedAction)).toEqual({isRunning: false});
+    const resolvedAction = {
+      type,
+      status,
+      context,
+      body,
+      receivedAt
+    };
+    expect(reducers[actionId](pendingState, resolvedAction)).toEqual({
+      isRunning: false
+    });
 
     status = 'rejected';
-    const rejectedAction = {type, status, context, err: {}, receivedAt};
-    expect(reducers[actionId](pendingState, rejectedAction)).toEqual({isRunning: false});
+    const rejectedAction = {
+      type,
+      status,
+      context,
+      err: {},
+      receivedAt
+    };
+    expect(reducers[actionId](pendingState, rejectedAction)).toEqual({
+      isRunning: false
+    });
   });
   it('should handle FETCH action', () => {
     const actionId = 'merge';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
     let status;
 
     status = 'pending';
-    const pendingState = reducers[actionId](undefined, {type, status});
-    expect(pendingState).toEqual({isMerging: true});
+    const pendingState = reducers[actionId](undefined, {
+      type,
+      status
+    });
+    expect(pendingState).toEqual({
+      isMerging: true
+    });
 
     status = 'resolved';
-    const body = [{id: 1, firstName: 'Olivier'}];
+    const body = [
+      {
+        id: 1,
+        firstName: 'Olivier'
+      }
+    ];
     const receivedAt = Date.now();
-    expect(reducers[actionId](pendingState, {type, status, body, receivedAt})).toEqual({isMerging: false});
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        body,
+        receivedAt
+      })
+    ).toEqual({
+      isMerging: false
+    });
 
     status = 'rejected';
-    expect(reducers[actionId](pendingState, {type, status, err: {}, receivedAt})).toEqual({isMerging: false});
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
+      isMerging: false
+    });
   });
 });
 
@@ -298,51 +991,123 @@ describe('custom pure reducers', () => {
   const customActions = {
     clear: {
       isPure: true,
-      reduce: (state, action) => ({...state, item: null})
+      reduce: (state, action) => ({
+        ...state,
+        item: null
+      })
     }
   };
-  const types = createTypes(customActions, {resourceName});
-  const reducers = createReducers(customActions, {resourceName});
+  const types = createTypes(customActions, {
+    resourceName
+  });
+  const reducers = createReducers(customActions, {
+    resourceName
+  });
   it('should handle CLEAR action', () => {
     const actionId = 'clear';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
-    const context = {firstName: 'Olivier'};
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const context = {
+      firstName: 'Olivier'
+    };
     let status;
 
-    const body = {ok: 1};
+    const body = {
+      ok: 1
+    };
     const receivedAt = Date.now();
-    const resolvedAction = {type, status, context, body, receivedAt};
-    expect(reducers[actionId](undefined, resolvedAction)).toEqual({item: null});
+    const resolvedAction = {
+      type,
+      status,
+      context,
+      body,
+      receivedAt
+    };
+    expect(reducers[actionId](undefined, resolvedAction)).toEqual({
+      item: null
+    });
   });
 });
 
 describe('reducer options', () => {
-  const types = createTypes(defaultActions, {resourceName});
+  const types = createTypes(defaultActions, {
+    resourceName
+  });
   describe('`assignResponse` option', () => {
     it('should handle GET action', () => {
       const actionId = 'get';
       const assignResponse = true;
       const reducers = createReducers(
-        {...defaultActions, [actionId]: {...defaultActions[actionId], assignResponse}},
-        {resourceName}
+        {
+          ...defaultActions,
+          [actionId]: {
+            ...defaultActions[actionId],
+            assignResponse
+          }
+        },
+        {
+          resourceName
+        }
       );
-      const type = types[getActionTypeKey(actionId, {resourceName})];
+      const type =
+        types[
+          getActionTypeKey(actionId, {
+            resourceName
+          })
+        ];
 
-      const initialItems = [{id: 1, firstName: 'Olivier', lastName: 'Louvignes'}];
-      const customInitialState = {items: initialItems};
-      const context = {id: 1};
-      const options = {assignResponse};
+      const initialItems = [
+        {
+          id: 1,
+          firstName: 'Olivier',
+          lastName: 'Louvignes'
+        }
+      ];
+      const customInitialState = {
+        items: initialItems
+      };
+      const context = {
+        id: 1
+      };
+      const options = {
+        assignResponse
+      };
       let status;
 
       status = 'pending';
-      const pendingState = reducers[actionId](customInitialState, {type, status, context});
-      expect(pendingState).toEqual({...customInitialState, isFetchingItem: true, didInvalidateItem: false});
+      const pendingState = reducers[actionId](customInitialState, {
+        type,
+        status,
+        context
+      });
+      expect(pendingState).toEqual({
+        ...customInitialState,
+        isFetchingItem: true,
+        didInvalidateItem: false
+      });
 
       status = 'resolved';
-      const body = {id: 1, firstName: 'Olivia', lastName: 'Louvignes'};
+      const body = {
+        id: 1,
+        firstName: 'Olivia',
+        lastName: 'Louvignes'
+      };
       const receivedAt = Date.now();
       const expectedItems = [body];
-      expect(reducers[actionId](pendingState, {type, status, context, options, body, receivedAt})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          context,
+          options,
+          body,
+          receivedAt
+        })
+      ).toEqual({
         isFetchingItem: false,
         didInvalidateItem: false,
         items: expectedItems,
@@ -351,7 +1116,16 @@ describe('reducer options', () => {
       });
 
       status = 'rejected';
-      expect(reducers[actionId](pendingState, {type, status, context, options, err: {}, receivedAt})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          context,
+          options,
+          err: {},
+          receivedAt
+        })
+      ).toEqual({
         ...customInitialState,
         didInvalidateItem: false,
         isFetchingItem: false
@@ -361,33 +1135,95 @@ describe('reducer options', () => {
       const actionId = 'update';
       const assignResponse = true;
       const reducers = createReducers(
-        {...defaultActions, [actionId]: {...defaultActions[actionId], assignResponse}},
-        {resourceName}
+        {
+          ...defaultActions,
+          [actionId]: {
+            ...defaultActions[actionId],
+            assignResponse
+          }
+        },
+        {
+          resourceName
+        }
       );
-      const type = types[getActionTypeKey(actionId, {resourceName})];
+      const type =
+        types[
+          getActionTypeKey(actionId, {
+            resourceName
+          })
+        ];
 
-      const initialItems = [{id: 1, firstName: 'Olivier', lastName: 'Louvignes'}];
-      const customInitialState = {...initialState, items: initialItems};
-      const context = {id: 1, firstName: 'Olivia'};
-      const options = {assignResponse};
+      const initialItems = [
+        {
+          id: 1,
+          firstName: 'Olivier',
+          lastName: 'Louvignes'
+        }
+      ];
+      const customInitialState = {
+        ...initialState,
+        items: initialItems
+      };
+      const context = {
+        id: 1,
+        firstName: 'Olivia'
+      };
+      const options = {
+        assignResponse
+      };
       let status;
 
       status = 'pending';
-      const pendingState = reducers[actionId](customInitialState, {type, status, context, options});
-      expect(pendingState).toEqual({...customInitialState, isUpdating: true});
+      const pendingState = reducers[actionId](customInitialState, {
+        type,
+        status,
+        context,
+        options
+      });
+      expect(pendingState).toEqual({
+        ...customInitialState,
+        isUpdating: true
+      });
 
       status = 'resolved';
-      const body = {id: 1, firstName: 'Olivia2'};
+      const body = {
+        id: 1,
+        firstName: 'Olivia2'
+      };
       const receivedAt = Date.now();
-      const expectedItems = [{id: 1, firstName: 'Olivia2', lastName: 'Louvignes'}];
-      expect(reducers[actionId](pendingState, {type, status, context, options, body, receivedAt})).toEqual({
+      const expectedItems = [
+        {
+          id: 1,
+          firstName: 'Olivia2',
+          lastName: 'Louvignes'
+        }
+      ];
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          context,
+          options,
+          body,
+          receivedAt
+        })
+      ).toEqual({
         ...customInitialState,
         isUpdating: false,
         items: expectedItems
       });
 
       status = 'rejected';
-      expect(reducers[actionId](pendingState, {type, status, context, options, err: {}, receivedAt})).toEqual({
+      expect(
+        reducers[actionId](pendingState, {
+          type,
+          status,
+          context,
+          options,
+          err: {},
+          receivedAt
+        })
+      ).toEqual({
         ...customInitialState,
         isUpdating: false
       });
@@ -397,99 +1233,272 @@ describe('reducer options', () => {
 
 describe('rootReducer', () => {
   it('should handle a default action', () => {
-    const types = createTypes(defaultActions, {resourceName});
-    const reducers = createReducers(defaultActions, {resourceName});
-    const rootReducer = createRootReducer(reducers, {resourceName});
+    const types = createTypes(defaultActions, {
+      resourceName
+    });
+    const reducers = createReducers(defaultActions, {
+      resourceName
+    });
+    const rootReducer = createRootReducer(reducers, {
+      resourceName
+    });
     const actionId = 'create';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
-    const context = {firstName: 'Olivier'};
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const context = {
+      firstName: 'Olivier'
+    };
     let status;
 
     status = 'pending';
-    const pendingAction = {type, status, context};
+    const pendingAction = {
+      type,
+      status,
+      context
+    };
     const pendingState = rootReducer(undefined, pendingAction);
-    expect(pendingState).toEqual({...initialState, isCreating: true});
+    expect(pendingState).toEqual({
+      ...initialState,
+      isCreating: true
+    });
 
     status = 'resolved';
-    const body = {id: 1, firstName: 'Olivier'};
+    const body = {
+      id: 1,
+      firstName: 'Olivier'
+    };
     const receivedAt = Date.now();
-    const resolvedAction = {type, status, context, body, receivedAt};
-    expect(rootReducer(pendingState, resolvedAction)).toEqual({...initialState, isCreating: false, items: [body]});
+    const resolvedAction = {
+      type,
+      status,
+      context,
+      body,
+      receivedAt
+    };
+    expect(rootReducer(pendingState, resolvedAction)).toEqual({
+      ...initialState,
+      isCreating: false,
+      items: [body]
+    });
 
     status = 'rejected';
-    const rejectedAction = {type, status, context, err: {}, receivedAt};
-    expect(rootReducer(pendingState, rejectedAction)).toEqual({...initialState, isCreating: false});
+    const rejectedAction = {
+      type,
+      status,
+      context,
+      err: {},
+      receivedAt
+    };
+    expect(rootReducer(pendingState, rejectedAction)).toEqual({
+      ...initialState,
+      isCreating: false
+    });
   });
   it('should handle a custom action', () => {
-    const customActions = {run: {method: 'POST', gerundName: 'running'}, merge: {method: 'POST', isArray: true}};
-    const types = createTypes(customActions, {resourceName});
-    const reducers = createReducers(customActions, {resourceName});
-    const rootReducer = createRootReducer(reducers, {resourceName});
+    const customActions = {
+      run: {
+        method: 'POST',
+        gerundName: 'running'
+      },
+      merge: {
+        method: 'POST',
+        isArray: true
+      }
+    };
+    const types = createTypes(customActions, {
+      resourceName
+    });
+    const reducers = createReducers(customActions, {
+      resourceName
+    });
+    const rootReducer = createRootReducer(reducers, {
+      resourceName
+    });
     const actionId = 'run';
-    const type = types[getActionTypeKey(actionId, {resourceName})];
-    const context = {firstName: 'Olivier'};
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const context = {
+      firstName: 'Olivier'
+    };
     let status;
 
     status = 'pending';
-    const pendingAction = {type, status, context};
+    const pendingAction = {
+      type,
+      status,
+      context
+    };
     const pendingState = rootReducer(undefined, pendingAction);
-    expect(pendingState).toEqual({...initialState, isRunning: true});
+    expect(pendingState).toEqual({
+      ...initialState,
+      isRunning: true
+    });
 
     status = 'resolved';
-    const body = {id: 1, firstName: 'Olivier'};
+    const body = {
+      id: 1,
+      firstName: 'Olivier'
+    };
     const receivedAt = Date.now();
-    const resolvedAction = {type, status, context, body, receivedAt};
-    expect(rootReducer(pendingState, resolvedAction)).toEqual({...initialState, isRunning: false});
+    const resolvedAction = {
+      type,
+      status,
+      context,
+      body,
+      receivedAt
+    };
+    expect(rootReducer(pendingState, resolvedAction)).toEqual({
+      ...initialState,
+      isRunning: false
+    });
 
     status = 'rejected';
-    const rejectedAction = {type, status, context, err: {}, receivedAt};
-    expect(rootReducer(pendingState, rejectedAction)).toEqual({...initialState, isRunning: false});
+    const rejectedAction = {
+      type,
+      status,
+      context,
+      err: {},
+      receivedAt
+    };
+    expect(rootReducer(pendingState, rejectedAction)).toEqual({
+      ...initialState,
+      isRunning: false
+    });
   });
   describe('should handle a pure action', () => {
     const customActions = {
       mockAll: {
         isPure: true,
         isArray: true,
-        reduce: (state, action) => ({...state, items: [{foo: 'bar'}]})
+        reduce: (state, action) => ({
+          ...state,
+          items: [
+            {
+              foo: 'bar'
+            }
+          ]
+        })
       }
     };
-    const types = createTypes(customActions, {resourceName});
-    const reducers = createReducers(customActions, {resourceName});
-    const rootReducer = createRootReducer(reducers, {resourceName});
+    const types = createTypes(customActions, {
+      resourceName
+    });
+    const reducers = createReducers(customActions, {
+      resourceName
+    });
+    const rootReducer = createRootReducer(reducers, {
+      resourceName
+    });
     const actionId = 'mockAll';
-    const type = types[getActionTypeKey(actionId, {resourceName, isArray: true})];
-    const context = {firstName: 'Olivier'};
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName,
+          isArray: true
+        })
+      ];
+    const context = {
+      firstName: 'Olivier'
+    };
 
     const status = 'resolved';
     const receivedAt = Date.now();
-    const resolvedAction = {type, status, context, receivedAt};
-    expect(rootReducer(initialState, resolvedAction)).toEqual({...initialState, items: [{foo: 'bar'}]});
+    const resolvedAction = {
+      type,
+      status,
+      context,
+      receivedAt
+    };
+    expect(rootReducer(initialState, resolvedAction)).toEqual({
+      ...initialState,
+      items: [
+        {
+          foo: 'bar'
+        }
+      ]
+    });
   });
 });
 
 describe('helpers', () => {
   describe('combineReducers', () => {
     it('should properly combine two reducer functions as a single object', () => {
-      const fooReducers = createRootReducer(createReducers(defaultActions, {resourceName: 'foo'}), {
-        resourceName: 'foo'
+      const fooReducers = createRootReducer(
+        createReducers(defaultActions, {
+          resourceName: 'foo'
+        }),
+        {
+          resourceName: 'foo'
+        }
+      );
+      const barReducers = createRootReducer(
+        createReducers(defaultActions, {
+          resourceName: 'bar'
+        }),
+        {
+          resourceName: 'bar'
+        }
+      );
+      const combinedReducers = combineReducers({
+        foo: fooReducers,
+        bar: barReducers
       });
-      const barReducers = createRootReducer(createReducers(defaultActions, {resourceName: 'bar'}), {
-        resourceName: 'bar'
-      });
-      const combinedReducers = combineReducers({foo: fooReducers, bar: barReducers});
       expect(typeof combinedReducers).toBe('function');
-      expect(Object.keys(combinedReducers({}, {type: 'foo'}))).toEqual(['foo', 'bar']);
+      expect(
+        Object.keys(
+          combinedReducers(
+            {},
+            {
+              type: 'foo'
+            }
+          )
+        )
+      ).toEqual(['foo', 'bar']);
     });
     it('should properly combine two reducer functions as two objects', () => {
-      const fooReducers = createRootReducer(createReducers(defaultActions, {resourceName: 'foo'}), {
-        resourceName: 'foo'
-      });
-      const barReducers = createRootReducer(createReducers(defaultActions, {resourceName: 'bar'}), {
-        resourceName: 'bar'
-      });
-      const combinedReducers = combineReducers({foo: fooReducers}, {bar: barReducers});
+      const fooReducers = createRootReducer(
+        createReducers(defaultActions, {
+          resourceName: 'foo'
+        }),
+        {
+          resourceName: 'foo'
+        }
+      );
+      const barReducers = createRootReducer(
+        createReducers(defaultActions, {
+          resourceName: 'bar'
+        }),
+        {
+          resourceName: 'bar'
+        }
+      );
+      const combinedReducers = combineReducers(
+        {
+          foo: fooReducers
+        },
+        {
+          bar: barReducers
+        }
+      );
       expect(typeof combinedReducers).toBe('function');
-      expect(Object.keys(combinedReducers({}, {type: 'foo'}))).toEqual(['foo', 'bar']);
+      expect(
+        Object.keys(
+          combinedReducers(
+            {},
+            {
+              type: 'foo'
+            }
+          )
+        )
+      ).toEqual(['foo', 'bar']);
     });
   });
 });

--- a/test/spec/reducers.spec.js
+++ b/test/spec/reducers.spec.js
@@ -575,7 +575,7 @@ describe('defaultReducers', () => {
     });
     expect(pendingState).toEqual({
       ...customInitialState,
-      isBatchUpdating: true
+      isUpdatingArray: true
     });
 
     status = 'resolved';
@@ -605,7 +605,7 @@ describe('defaultReducers', () => {
         receivedAt
       })
     ).toEqual({
-      isBatchUpdating: false,
+      isUpdatingArray: false,
       items: expectedItems,
       item: expectedItem
     });
@@ -621,7 +621,7 @@ describe('defaultReducers', () => {
       })
     ).toEqual({
       ...customInitialState,
-      isBatchUpdating: false
+      isUpdatingArray: false
     });
   });
   it('should handle UPDATE_ARRAY action with ids in query object', () => {
@@ -662,7 +662,7 @@ describe('defaultReducers', () => {
     });
     expect(pendingState).toEqual({
       ...customInitialState,
-      isBatchUpdating: true
+      isUpdatingArray: true
     });
 
     status = 'resolved';
@@ -692,7 +692,7 @@ describe('defaultReducers', () => {
         receivedAt
       })
     ).toEqual({
-      isBatchUpdating: false,
+      isUpdatingArray: false,
       items: expectedItems,
       item: expectedItem
     });
@@ -708,7 +708,7 @@ describe('defaultReducers', () => {
       })
     ).toEqual({
       ...customInitialState,
-      isBatchUpdating: false
+      isUpdatingArray: false
     });
   });
   it('should handle UPDATE_ARRAY action with assignResponse to true', () => {
@@ -750,7 +750,7 @@ describe('defaultReducers', () => {
     });
     expect(pendingState).toEqual({
       ...customInitialState,
-      isBatchUpdating: true
+      isUpdatingArray: true
     });
 
     status = 'resolved';
@@ -778,7 +778,7 @@ describe('defaultReducers', () => {
         receivedAt
       })
     ).toEqual({
-      isBatchUpdating: false,
+      isUpdatingArray: false,
       items: expectedItems,
       item: expectedItem
     });
@@ -794,7 +794,7 @@ describe('defaultReducers', () => {
       })
     ).toEqual({
       ...customInitialState,
-      isBatchUpdating: false
+      isUpdatingArray: false
     });
   });
   it('should handle DELETE action', () => {

--- a/test/spec/reducers.spec.js
+++ b/test/spec/reducers.spec.js
@@ -864,6 +864,153 @@ describe('defaultReducers', () => {
       isDeleting: false
     });
   });
+  it('should handle DELETE_ARRAY action with ids in query object', () => {
+    const actionId = snakeCase('deleteArray');
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const initialItems = [
+      {
+        id: 1,
+        firstName: 'Olivier',
+        lastName: 'Louvignes'
+      },
+      {
+        id: 2,
+        firstName: 'Nathan',
+        lastName: 'Ducrey'
+      }
+    ];
+    const customInitialState = {
+      items: initialItems,
+      item: initialItems[0]
+    };
+    const context = {};
+    let status;
+
+    status = 'pending';
+    const pendingState = reducers[actionId](customInitialState, {
+      type,
+      status,
+      context,
+      query: {ids: [1, 2]}
+    });
+    expect(pendingState).toEqual({
+      ...customInitialState,
+      isArrayDeleting: true
+    });
+
+    status = 'resolved';
+    const body = {
+      ok: true
+    };
+    const receivedAt = Date.now();
+    const expectedItems = [];
+    const expectedItem = null;
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        body,
+        receivedAt
+      })
+    ).toEqual({
+      isArrayDeleting: false,
+      items: expectedItems,
+      item: expectedItem
+    });
+
+    status = 'rejected';
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
+      ...customInitialState,
+      isArrayDeleting: false
+    });
+  });
+  it('should handle DELETE_ARRAY action with ids in context object', () => {
+    const actionId = snakeCase('deleteArray');
+    const type =
+      types[
+        getActionTypeKey(actionId, {
+          resourceName
+        })
+      ];
+    const initialItems = [
+      {
+        id: 1,
+        firstName: 'Olivier',
+        lastName: 'Louvignes'
+      },
+      {
+        id: 2,
+        firstName: 'Nathan',
+        lastName: 'Ducrey'
+      }
+    ];
+    const customInitialState = {
+      items: initialItems,
+      item: initialItems[0]
+    };
+    const context = {ids: [1, 2]};
+    let status;
+
+    status = 'pending';
+    const pendingState = reducers[actionId](customInitialState, {
+      type,
+      status,
+      context
+    });
+    expect(pendingState).toEqual({
+      ...customInitialState,
+      isArrayDeleting: true
+    });
+
+    status = 'resolved';
+    const body = {
+      ok: true
+    };
+    const receivedAt = Date.now();
+    const expectedItems = [];
+    const expectedItem = null;
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        body,
+        receivedAt
+      })
+    ).toEqual({
+      isArrayDeleting: false,
+      items: expectedItems,
+      item: expectedItem
+    });
+
+    status = 'rejected';
+    expect(
+      reducers[actionId](pendingState, {
+        type,
+        status,
+        context,
+        err: {},
+        receivedAt
+      })
+    ).toEqual({
+      ...customInitialState,
+      isArrayDeleting: false
+    });
+  });
 });
 
 describe('custom reducers', () => {

--- a/test/spec/reducers.spec.js
+++ b/test/spec/reducers.spec.js
@@ -657,8 +657,7 @@ describe('defaultReducers', () => {
     const pendingState = reducers[actionId](customInitialState, {
       type,
       status,
-      context,
-      query: {ids: [1, 2]}
+      context
     });
     expect(pendingState).toEqual({
       ...customInitialState,
@@ -703,6 +702,7 @@ describe('defaultReducers', () => {
         type,
         status,
         context,
+        query: {ids: [1, 2]},
         err: {},
         receivedAt
       })
@@ -744,9 +744,7 @@ describe('defaultReducers', () => {
     const pendingState = reducers[actionId](customInitialState, {
       type,
       status,
-      context,
-      query: {ids: [1, 2]},
-      assignResponse: true
+      context
     });
     expect(pendingState).toEqual({
       ...customInitialState,
@@ -775,7 +773,9 @@ describe('defaultReducers', () => {
         status,
         context,
         body,
-        receivedAt
+        receivedAt,
+        query: {ids: [1, 2]},
+        options: {assignResponse: true}
       })
     ).toEqual({
       isUpdatingArray: false,

--- a/test/spec/types.spec.js
+++ b/test/spec/types.spec.js
@@ -1,13 +1,7 @@
 import expect from 'expect';
-import {
-  values
-} from 'lodash';
-import {
-  createTypes
-} from '../../src/types';
-import {
-  defaultActions
-} from '../../src/defaults';
+import {values} from 'lodash';
+import {createTypes} from '../../src/types';
+import {defaultActions} from '../../src/defaults';
 
 describe('createTypes', () => {
   describe('when using a resource', () => {
@@ -16,7 +10,7 @@ describe('createTypes', () => {
       const types = createTypes(defaultActions, {
         resourceName
       });
-      const expectedKeys = ['CREATE_USER', 'FETCH_USERS', 'GET_USER', 'UPDATE_USER', 'UPDATE_USERS', 'DELETE_USER'];
+      const expectedKeys = ['CREATE_USER', 'FETCH_USERS', 'GET_USER', 'UPDATE_USER', 'UPDATE_USERS', 'DELETE_USER', 'DELETE_USERS'];
       expect(Object.keys(types)).toEqual(expectedKeys);
       const expectedValues = [
         '@@resource/USER/CREATE',
@@ -24,7 +18,8 @@ describe('createTypes', () => {
         '@@resource/USER/GET',
         '@@resource/USER/UPDATE',
         '@@resource/USER/UPDATE_ARRAY',
-        '@@resource/USER/DELETE'
+        '@@resource/USER/DELETE',
+        '@@resource/USER/DELETE_ARRAY'
       ];
       expect(values(types)).toEqual(expectedValues);
     });
@@ -32,9 +27,9 @@ describe('createTypes', () => {
   describe('when not using a resource', () => {
     it('should properly return an object with properly named keys', () => {
       const types = createTypes(defaultActions, {});
-      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
+      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE', 'DELETE_ARRAY'];
       expect(Object.keys(types)).toEqual(expectedKeys);
-      const expectedValues = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
+      const expectedValues = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE', 'DELETE_ARRAY'];
       expect(values(types)).toEqual(expectedValues);
     });
   });
@@ -43,9 +38,9 @@ describe('createTypes', () => {
       const types = createTypes(defaultActions, {
         scope: false
       });
-      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
+      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE', 'DELETE_ARRAY'];
       expect(Object.keys(types)).toEqual(expectedKeys);
-      const expectedValues = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
+      const expectedValues = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE', 'DELETE_ARRAY'];
       expect(values(types)).toEqual(expectedValues);
     });
   });
@@ -54,7 +49,7 @@ describe('createTypes', () => {
       const types = createTypes(defaultActions, {
         scope: '@@custom/TEAM'
       });
-      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
+      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE', 'DELETE_ARRAY'];
       expect(Object.keys(types)).toEqual(expectedKeys);
       const expectedValues = [
         '@@custom/TEAM/CREATE',
@@ -62,7 +57,8 @@ describe('createTypes', () => {
         '@@custom/TEAM/GET',
         '@@custom/TEAM/UPDATE',
         '@@custom/TEAM/UPDATE_ARRAY',
-        '@@custom/TEAM/DELETE'
+        '@@custom/TEAM/DELETE',
+        '@@custom/TEAM/DELETE_ARRAY'
       ];
       expect(values(types)).toEqual(expectedValues);
     });

--- a/test/spec/types.spec.js
+++ b/test/spec/types.spec.js
@@ -1,20 +1,29 @@
 import expect from 'expect';
-import {values} from 'lodash';
-import {createTypes} from '../../src/types';
-import {defaultActions} from '../../src/defaults';
+import {
+  values
+} from 'lodash';
+import {
+  createTypes
+} from '../../src/types';
+import {
+  defaultActions
+} from '../../src/defaults';
 
 describe('createTypes', () => {
   describe('when using a resource', () => {
     it('should properly return an object with properly named keys', () => {
       const resourceName = 'user';
-      const types = createTypes(defaultActions, {resourceName});
-      const expectedKeys = ['CREATE_USER', 'FETCH_USERS', 'GET_USER', 'UPDATE_USER', 'DELETE_USER'];
+      const types = createTypes(defaultActions, {
+        resourceName
+      });
+      const expectedKeys = ['CREATE_USER', 'FETCH_USERS', 'GET_USER', 'UPDATE_USER', 'UPDATE_USERS', 'DELETE_USER'];
       expect(Object.keys(types)).toEqual(expectedKeys);
       const expectedValues = [
         '@@resource/USER/CREATE',
         '@@resource/USER/FETCH',
         '@@resource/USER/GET',
         '@@resource/USER/UPDATE',
+        '@@resource/USER/UPDATE_ARRAY',
         '@@resource/USER/DELETE'
       ];
       expect(values(types)).toEqual(expectedValues);
@@ -23,31 +32,36 @@ describe('createTypes', () => {
   describe('when not using a resource', () => {
     it('should properly return an object with properly named keys', () => {
       const types = createTypes(defaultActions, {});
-      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'DELETE'];
+      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
       expect(Object.keys(types)).toEqual(expectedKeys);
-      const expectedValues = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'DELETE'];
+      const expectedValues = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
       expect(values(types)).toEqual(expectedValues);
     });
   });
   describe('when using a falsy scope', () => {
     it('should properly return an object with properly named keys', () => {
-      const types = createTypes(defaultActions, {scope: false});
-      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'DELETE'];
+      const types = createTypes(defaultActions, {
+        scope: false
+      });
+      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
       expect(Object.keys(types)).toEqual(expectedKeys);
-      const expectedValues = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'DELETE'];
+      const expectedValues = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
       expect(values(types)).toEqual(expectedValues);
     });
   });
   describe('when using a custom scope', () => {
     it('should properly return an object with properly named keys', () => {
-      const types = createTypes(defaultActions, {scope: '@@custom/TEAM'});
-      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'DELETE'];
+      const types = createTypes(defaultActions, {
+        scope: '@@custom/TEAM'
+      });
+      const expectedKeys = ['CREATE', 'FETCH', 'GET', 'UPDATE', 'UPDATE_ARRAY', 'DELETE'];
       expect(Object.keys(types)).toEqual(expectedKeys);
       const expectedValues = [
         '@@custom/TEAM/CREATE',
         '@@custom/TEAM/FETCH',
         '@@custom/TEAM/GET',
         '@@custom/TEAM/UPDATE',
+        '@@custom/TEAM/UPDATE_ARRAY',
         '@@custom/TEAM/DELETE'
       ];
       expect(values(types)).toEqual(expectedValues);
@@ -56,8 +70,18 @@ describe('createTypes', () => {
   describe('when using custom actions', () => {
     it('should properly return an object with properly named keys', () => {
       const resourceName = 'team';
-      const customActions = {promote: {method: 'POST'}, merge: {method: 'POST', isArray: true}};
-      const types = createTypes(customActions, {resourceName});
+      const customActions = {
+        promote: {
+          method: 'POST'
+        },
+        merge: {
+          method: 'POST',
+          isArray: true
+        }
+      };
+      const types = createTypes(customActions, {
+        resourceName
+      });
       const expectedKeys = ['PROMOTE_TEAM', 'MERGE_TEAMS'];
       expect(Object.keys(types)).toEqual(expectedKeys);
       const expectedValues = ['@@resource/TEAM/PROMOTE', '@@resource/TEAM/MERGE'];


### PR DESCRIPTION
Add 2 default actions:
- __updateArray:__ use one request to apply the same update on several items
- __deleteArray:__ use one request to delete several item in one time

The user is able to provide items' ids through the context object or the query object in action's options.
If the user provides no ids then the update/delete will be applied on all items in the state.