### PR TITLE
Add stripTrailingSlashes param

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -17,7 +17,7 @@ const getActionName = (
 
 const createAction = (
   actionId,
-  {resourceName, resourcePluralName = getPluralName(resourceName), scope, ...actionOpts}
+  {resourceName, resourcePluralName = getPluralName(resourceName), scope, stripTrailingSlashes = true, ...actionOpts}
 ) => {
   const type = scopeType(getActionType(actionId), scope);
   // Actual action function with two args
@@ -68,7 +68,8 @@ const createAction = (
     const finalFetchUrl = buildFetchUrl(context, {
       url,
       urlParams,
-      isArray: reduceOpts.isArray
+      isArray: reduceOpts.isArray,
+      stripTrailingSlashes
     });
     const finalFetchOpts = buildFetchOpts(context, eligibleFetchOptions);
     return fetch(finalFetchUrl, finalFetchOpts)


### PR DESCRIPTION
The user is able to provide `stripTrailingSlashes` parameter when creating a resource with the `createResource` function.

`_stripTrailingSlashes_` is meant to be a boolean that allow the user to choose wether he want to strip the trailing slashes at the end of the action url or not. It is useful when you have a API with required trailing slashes for any reason.

Use case example :
~~~javascript
import { createResource } from 'redux-rest-resource'
import { baseURL } from './'

export const { types, actions, rootReducer } = createResource({
  name: 'auth',
  url: `${baseURL}`,
  actions: {
    login: {
      method: 'POST',
      gerundName: 'loggingIn',
      url: './login/app/'
    }
  },
  stripTrailingSlashes: false
})
~~~