### PR TITLE
Fixes for deleteMany action

### DIFF
--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -68,7 +68,7 @@ export const buildFetchOpts = (context, {method, headers, credentials, query, bo
   if (query) {
     opts.query = query;
   }
-  const hasBody = /^(POST|PUT|PATCH)$/i.test(opts.method);
+  const hasBody = /^(POST|PUT|PATCH|DELETE)$/i.test(opts.method);
   if (hasBody) {
     if (body) {
       opts.body = isString(body) ? body : JSON.stringify(body);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -279,7 +279,7 @@ const defaultReducers = {
           ...state,
           isDeletingMany: false,
           items: [...state.items.filter(el => !ids.includes(el[idKey]))],
-          item: ids.includes(state.item[idKey]) ? null : state.item
+          item: state.item && ids.includes(state.item[idKey]) ? null : state.item
         };
       }
       case 'rejected':


### PR DESCRIPTION
I noticed two points:
- the `DELETE` method was not checked in the fetch helper, in order to be able to add a body in a delete request.
- prevent error when `item` is null in `deleteMany` reducer