### PR TITLE
Fix: Added check if fetch is available in global scope

### DIFF
--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -48,7 +48,7 @@ const initialState = Object.keys(defaultState).reduce((soFar, key) => ({...soFar
 
 const defaultGlobals = {
   Promise,
-  fetch
+  fetch: (typeof fetch !== 'undefined') ? fetch : null
 };
 
 export {defaultGlobals, defaultActions, defaultHeaders, defaultIdKeys, defaultState, initialState};

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -48,7 +48,7 @@ const initialState = Object.keys(defaultState).reduce((soFar, key) => ({...soFar
 
 const defaultGlobals = {
   Promise,
-  fetch: (typeof fetch !== 'undefined') ? fetch : null
+  fetch: typeof fetch !== 'undefined' ? fetch : null
 };
 
 export {defaultGlobals, defaultActions, defaultHeaders, defaultIdKeys, defaultState, initialState};


### PR DESCRIPTION
Added check if fetch is available in global scope. Otherwise a webpack-bundle of a server-side rendered app will fail with a ReferenceError.

I'm currently using this library in a [nextjs](https://nextjs.org/) environment. Currently a production build fails with a ReferenceError because fetch is not defined. Checking if fetch is available fixes this issue.

Maybe a similar check for `Promise` would also make sense to add.